### PR TITLE
Airac 201910

### DIFF
--- a/database/migrations/2019_09_14_094017_update_gatwick_departures.php
+++ b/database/migrations/2019_09_14_094017_update_gatwick_departures.php
@@ -1,0 +1,61 @@
+<?php
+
+use App\Models\Airfield;
+use App\Models\Sid;
+use Illuminate\Database\Migrations\Migration;
+
+class UpdateGatwickDepartures extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $gatwick = Airfield::where('code', 'EGKK')->firstOrFail()->id;
+
+        $sids = [
+            'LAM5M' => 'LAM6M',
+            'LAM5V' => 'LAM6V',
+            'CLN9M' => 'CLN1M',
+            'CLN9V' => 'CLN1V',
+            'DVR9M' => 'DVR1M',
+            'DVR9V' => 'DVR1V',
+        ];
+
+        foreach ($sids as $old => $new) {
+            $this->updateSid($gatwick, $old, $new);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $gatwick = Airfield::where('code', 'EGKK')->firstOrFail()->id;
+
+        $sids = [
+            'LAM6M' => 'LAM5M',
+            'LAM6V' => 'LAM5V',
+            'CLN1M' => 'CLN9M',
+            'CLN1V' => 'CLN9V',
+            'DVR1M' => 'DVR9M',
+            'DVR1V' => 'DVR9V',
+        ];
+
+        foreach ($sids as $old => $new) {
+            $this->updateSid($gatwick, $old, $new);
+        }
+    }
+
+    private function updateSid(int $gatwickAirfieldId, string $oldIdentifier, string $newIdentifier) : void
+    {
+        Sid::where('airfield_id', $gatwickAirfieldId)
+            ->where('identifier', $oldIdentifier)
+            ->update(['identifier' => $newIdentifier]);
+    }
+}

--- a/database/migrations/2019_09_14_094914_update_cambridge_squawk_range.php
+++ b/database/migrations/2019_09_14_094914_update_cambridge_squawk_range.php
@@ -1,0 +1,70 @@
+<?php
+
+use App\Models\Squawks\Range;
+use App\Models\Squawks\SquawkUnit;
+use Illuminate\Database\Migrations\Migration;
+
+class UpdateCambridgeSquawkRange extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $cambridge = SquawkUnit::where('unit', 'EGSC')->firstOrFail();
+
+        // Delete the old ranges
+        $cambridge->ranges->each(function (Range $range) {
+            $range->delete();
+        });
+
+        // Add new ranges
+
+        Range::create(
+            [
+                'squawk_range_owner_id' => $cambridge->rangeOwner->id,
+                'start' => '6160',
+                'stop' => '6175',
+                'rules' => 'A',
+                'allow_duplicate' => false,
+            ]
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $cambridge = SquawkUnit::where('unit', 'EGSC')->firstOrFail();
+
+        // Delete the old ranges
+        $cambridge->ranges->each(function (Range $range) {
+            $range->delete();
+        });
+
+        // Add new ranges
+        Range::insert(
+            [
+                [
+                    'squawk_range_owner_id' => $cambridge->rangeOwner->id,
+                    'start' => '6160',
+                    'stop' => '6176',
+                    'rules' => 'A',
+                    'allow_duplicate' => false,
+                ],
+                [
+                    'squawk_range_owner_id' => $cambridge->rangeOwner->id,
+                    'start' => '6171',
+                    'stop' => '6177',
+                    'rules' => 'A',
+                    'allow_duplicate' => false,
+                ],
+            ]
+        );
+    }
+}

--- a/storage/app/public/dependencies/airfield-ownership.json
+++ b/storage/app/public/dependencies/airfield-ownership.json
@@ -335,8 +335,26 @@
         "LON_SC_CTR",
         "LON_CTR"
     ],
+    "EGPA": [
+        "EGPA_TWR",
+        "EGPA_APP",
+        "SCO_E_CTR",
+        "SCO_CTR"
+    ],
     "EGPB": [
         "EGPB_TWR",
+        "SCO_E_CTR",
+        "SCO_CTR"
+    ],
+    "EGPB": [
+        "EGPB_TWR",
+        "EGPB_APP",
+        "SCO_E_CTR",
+        "SCO_CTR"
+    ],
+    "EGPC": [
+        "EGPC_TWR",
+        "EGPC_APP",
         "SCO_E_CTR",
         "SCO_CTR"
     ],

--- a/storage/app/public/dependencies/airfield-ownership.json
+++ b/storage/app/public/dependencies/airfield-ownership.json
@@ -58,7 +58,7 @@
         "EGCC_F_APP",
         "EGCC_S_APP",
         "EGCC_N_APP",
-        "MAN_E_CTR",
+        "MAN_W_CTR",
         "MAN_CTR",
         "LON_N_CTR",
         "LON_CTR"

--- a/storage/app/public/dependencies/airfield-ownership.json
+++ b/storage/app/public/dependencies/airfield-ownership.json
@@ -367,6 +367,7 @@
         "EGPD_TWR",
         "EGPD_APP",
         "EGPD_F_APP",
+        "SCO_S_CTR",
         "SCO_E_CTR",
         "SCO_CTR"
     ],
@@ -387,6 +388,7 @@
         "STC_CTR",
         "SCO_D_CTR",
         "SCO_WD_CTR",
+        "SCO_S_CTR",
         "SCO_CTR"
     ],
     "EGPH": [
@@ -397,6 +399,7 @@
         "STC_CTR",
         "SCO_D_CTR",
         "SCO_WD_CTR",
+        "SCO_S_CTR",
         "SCO_CTR"
     ],
     "EGPK": [
@@ -408,6 +411,7 @@
         "STC_CTR",
         "SCO_D_CTR",
         "SCO_WD_CTR",
+        "SCO_S_CTR",
         "SCO_CTR"
     ],
     "EGPM": [
@@ -420,6 +424,7 @@
     "EGPN": [
         "EGPN_TWR",
         "EGPN_APP",
+        "SCO_S_CTR",
         "SCO_E_CTR",
         "SCO_CTR"
     ],

--- a/storage/app/public/dependencies/airfield-ownership.json
+++ b/storage/app/public/dependencies/airfield-ownership.json
@@ -338,23 +338,27 @@
     "EGPA": [
         "EGPA_TWR",
         "EGPA_APP",
+        "SCO_N_CTR",
         "SCO_E_CTR",
         "SCO_CTR"
     ],
     "EGPB": [
         "EGPB_TWR",
+        "SCO_N_CTR",
         "SCO_E_CTR",
         "SCO_CTR"
     ],
     "EGPB": [
         "EGPB_TWR",
         "EGPB_APP",
+        "SCO_N_CTR",
         "SCO_E_CTR",
         "SCO_CTR"
     ],
     "EGPC": [
         "EGPC_TWR",
         "EGPC_APP",
+        "SCO_N_CTR",
         "SCO_E_CTR",
         "SCO_CTR"
     ],
@@ -370,6 +374,7 @@
         "EGPE_TWR",
         "EGPE_R_APP",
         "EGPE_APP",
+        "SCO_N_CTR",
         "SCO_E_CTR",
         "SCO_CTR"
     ],
@@ -408,6 +413,7 @@
     "EGPM": [
         "EGPM_TWR",
         "EGPM_APP",
+        "SCO_N_CTR",
         "SCO_E_CTR",
         "SCO_CTR"
     ],
@@ -420,6 +426,7 @@
     "EGPO": [
         "EGPO_TWR",
         "EGPO_APP",
+        "SCO_N_CTR",
         "SCO_E_CTR",
         "SCO_CTR"
     ],

--- a/storage/app/public/dependencies/airfield-ownership.json
+++ b/storage/app/public/dependencies/airfield-ownership.json
@@ -2,8 +2,8 @@
     "EGAA": [
         "EGAA_GND",
         "EGAA_TWR",
-        "EGAA_R_APP",
         "EGAA_APP",
+        "EGAA_R_APP",
         "STC_A_CTR",
         "SCO_R_CTR",
         "SCO_W_CTR",
@@ -13,6 +13,7 @@
     "EGAC": [
         "EGAC_TWR",
         "EGAC_APP",
+        "EGAA_R_APP",
         "STC_A_CTR",
         "SCO_R_CTR",
         "SCO_W_CTR",

--- a/storage/app/public/dependencies/airfield-ownership.json
+++ b/storage/app/public/dependencies/airfield-ownership.json
@@ -344,12 +344,6 @@
     ],
     "EGPB": [
         "EGPB_TWR",
-        "SCO_N_CTR",
-        "SCO_E_CTR",
-        "SCO_CTR"
-    ],
-    "EGPB": [
-        "EGPB_TWR",
         "EGPB_APP",
         "SCO_N_CTR",
         "SCO_E_CTR",

--- a/storage/app/public/dependencies/airfield-ownership.json
+++ b/storage/app/public/dependencies/airfield-ownership.json
@@ -58,6 +58,7 @@
         "EGCC_F_APP",
         "EGCC_S_APP",
         "EGCC_N_APP",
+        "MAN_WL_CTR",
         "MAN_W_CTR",
         "MAN_CTR",
         "LON_N_CTR",

--- a/storage/app/public/dependencies/controller-positions.json
+++ b/storage/app/public/dependencies/controller-positions.json
@@ -1392,6 +1392,7 @@
     "MAN_W_CTR": {
         "frequency": 128.05,
         "top-down": [
+            "EGCC",
             "EGGP",
             "EGNR",
             "EGNH",
@@ -1401,7 +1402,6 @@
     "MAN_E_CTR": {
         "frequency": 133.8,
         "top-down": [
-            "EGCC",
             "EGNM",
             "EGNJ",
             "EGNC",

--- a/storage/app/public/dependencies/controller-positions.json
+++ b/storage/app/public/dependencies/controller-positions.json
@@ -774,10 +774,6 @@
         "frequency": 119.7,
         "top-down": []
     },
-    "EGPC_ATIS": {
-        "frequency": 119.7,
-        "top-down": []
-    },
     "EGPC_TWR": {
         "frequency": 119.7,
         "top-down": []

--- a/storage/app/public/dependencies/controller-positions.json
+++ b/storage/app/public/dependencies/controller-positions.json
@@ -1509,7 +1509,7 @@
         ]
     },
     "STC_CTR": {
-        "frequency": 124.82,
+        "frequency": 126.3,
         "top-down": [
             "EGNC",
             "EGPF",
@@ -1525,7 +1525,7 @@
         ]
     },
     "STC_W_CTR": {
-        "frequency": 121.37,
+        "frequency": 124.82,
         "top-down": [
             "EGPF",
             "EGPK"

--- a/storage/app/public/dependencies/controller-positions.json
+++ b/storage/app/public/dependencies/controller-positions.json
@@ -1488,6 +1488,16 @@
             "EGAE"
         ]
     },
+    "SCO_S_CTR": {
+        "frequency": 134.77,
+        "top-down": [
+            "EGPD",
+            "EGPF",
+            "EGPH",
+            "EGPK",
+            "EGPN"
+        ]
+    },
     "SCO_WD_CTR": {
         "frequency": 133.2,
         "top-down": [

--- a/storage/app/public/dependencies/controller-positions.json
+++ b/storage/app/public/dependencies/controller-positions.json
@@ -1399,6 +1399,13 @@
             "EGNS"
         ]
     },
+    "MAN_WL_CTR": {
+        "frequency": 125.95,
+        "top-down": [
+            "EGCC",
+            "EGGP"
+        ]
+    },
     "MAN_E_CTR": {
         "frequency": 133.8,
         "top-down": [

--- a/storage/app/public/dependencies/controller-positions.json
+++ b/storage/app/public/dependencies/controller-positions.json
@@ -1336,6 +1336,14 @@
         "frequency": 129.6,
         "top-down": []
     },
+    "LTC_ER_CTR": {
+        "frequency": 133.52,
+        "top-down": []
+    },
+    "LTC_ES_CTR": {
+        "frequency": 135.42,
+        "top-down": []
+    },
     "LTC_NE_CTR": {
         "frequency": 118.82,
         "top-down": []

--- a/storage/app/public/dependencies/controller-positions.json
+++ b/storage/app/public/dependencies/controller-positions.json
@@ -1469,6 +1469,17 @@
             "EGPM"
         ]
     },
+    "SCO_N_CTR": {
+        "frequency": 129.220,
+        "top-down": [
+            "EGPA",
+            "EGPB",
+            "EGPC",
+            "EGPE",
+            "EGPM",
+            "EGPO"
+        ]
+    },
     "SCO_R_CTR": {
         "frequency": 129.1,
         "top-down": [

--- a/storage/app/public/dependencies/controller-positions.json
+++ b/storage/app/public/dependencies/controller-positions.json
@@ -1451,6 +1451,10 @@
             "EGPM"
         ]
     },
+    "SCO_C_CTR": {
+        "frequency": 127.27,
+        "top-down": []
+    },
     "SCO_D_CTR": {
         "frequency": 135.85,
         "top-down": [

--- a/storage/app/public/dependencies/controller-positions.json
+++ b/storage/app/public/dependencies/controller-positions.json
@@ -2,8 +2,7 @@
     "EGAA_APP": {
         "frequency": 120.9,
         "top-down": [
-            "EGAA",
-            "EGAC"
+            "EGAA"
         ]
     },
     "EGAA_GND": {
@@ -15,7 +14,8 @@
     "EGAA_R_APP": {
         "frequency": 128.5,
         "top-down": [
-            "EGAA"
+            "EGAA",
+            "EGAC"
         ]
     },
     "EGAA_TWR": {


### PR DESCRIPTION
Close #49 

- Update Cambridge Squawk Rangers
- Update Gatwick Non-RNAV Departures
- Add New Scottish Sectors
- Add New TC East Splits
- Update Scottish TMA Frequencies
- Add missing top-downs for EGPA and EGPC
- Added Manchester Wallasey Sector
- Changed EGCC Ownership To MAN_W
- Fixed Top Down Order on EGAA
- Added EGAA INT to Top Down For EGAC