### PR TITLE
Fire Squawk Assignment Event

### DIFF
--- a/app/Services/SquawkService.php
+++ b/app/Services/SquawkService.php
@@ -121,6 +121,7 @@ class SquawkService
             }
         });
 
+        // If a squawk has been assigned, let the rest of the app know so it can be audited etc
         if (!is_null($assignment)) {
             event(new SquawkAssignmentEvent($assignment));
         }

--- a/app/Services/SquawkService.php
+++ b/app/Services/SquawkService.php
@@ -120,6 +120,10 @@ class SquawkService
             }
         });
 
+        if (!is_null($assignment)) {
+            event(new SquawkAssignmentEvent($assignment));
+        }
+
         return $assignment;
     }
 

--- a/app/Services/SquawkService.php
+++ b/app/Services/SquawkService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Allocator\Squawk\SquawkAllocatorInterface;
 use App\Allocator\Squawk\SquawkAssignmentCategories;
 use App\Allocator\Squawk\SquawkAssignmentInterface;
+use App\Events\SquawkAssignmentEvent;
 use App\Events\SquawkUnassignedEvent;
 use Illuminate\Support\Facades\DB;
 

--- a/tests/app/Services/SquawkServiceTest.php
+++ b/tests/app/Services/SquawkServiceTest.php
@@ -7,6 +7,7 @@ use App\Allocator\Squawk\General\CcamsSquawkAllocator;
 use App\Allocator\Squawk\General\OrcamSquawkAllocator;
 use App\Allocator\Squawk\Local\UnitDiscreteSquawkAllocator;
 use App\BaseFunctionalTestCase;
+use App\Events\SquawkAssignmentEvent;
 use App\Events\SquawkUnassignedEvent;
 use App\Models\Squawk\Ccams\CcamsSquawkAssignment;
 use App\Models\Squawk\Ccams\CcamsSquawkRange;
@@ -77,6 +78,7 @@ class SquawkServiceTest extends BaseFunctionalTestCase
 
     public function testItAssignsALocalSquawkAndReturnsIt()
     {
+        $this->expectsEvents(SquawkAssignmentEvent::class);
         $assignment = $this->squawkService->assignLocalSquawk('BAW123', 'EGKK_APP', 'I');
         $this->assertEquals('0202', $assignment->getCode());
         $this->assertEquals('UNIT_DISCRETE', $assignment->getType());
@@ -85,12 +87,14 @@ class SquawkServiceTest extends BaseFunctionalTestCase
 
     public function testItDoesntAssignLocalSquawkIfAllocatorFails()
     {
+        $this->doesntExpectEvents(SquawkAssignmentEvent::class);
         UnitDiscreteSquawkRange::getQuery()->delete();
         $this->assertNull($this->squawkService->assignLocalSquawk('BAW123', 'EGKK_APP', 'I'));
     }
 
     public function testItAssignsAGeneralSquawkAndReturnsIt()
     {
+        $this->expectsEvents(SquawkAssignmentEvent::class);
         $assignment = $this->squawkService->assignGeneralSquawk('BAW123', 'KJFK', 'EGLL');
         $this->assertEquals('0101', $assignment->getCode());
         $this->assertEquals('ORCAM', $assignment->getType());
@@ -99,6 +103,7 @@ class SquawkServiceTest extends BaseFunctionalTestCase
 
     public function testItDoesntAssignGeneralSquawkIfAllocatorFails()
     {
+        $this->doesntExpectEvents(SquawkAssignmentEvent::class);
         OrcamSquawkRange::getQuery()->delete();
         CcamsSquawkRange::getQuery()->delete();
         $this->assertNull($this->squawkService->assignGeneralSquawk('BAW123', 'EGKK', 'EGLL'));
@@ -106,6 +111,7 @@ class SquawkServiceTest extends BaseFunctionalTestCase
 
     public function testItTriesNextAllocatorIfGeneralAllocationFails()
     {
+        $this->expectsEvents(SquawkAssignmentEvent::class);
         CcamsSquawkRange::create(
             [
                 'first' => '0303',


### PR DESCRIPTION
- Add the missing event to properly trigger squawk auditing.