### PR TITLE
Prevent squawk integrity violations

### DIFF
--- a/app/Allocator/Squawk/General/AirfieldPairingSquawkAllocator.php
+++ b/app/Allocator/Squawk/General/AirfieldPairingSquawkAllocator.php
@@ -23,41 +23,60 @@ class AirfieldPairingSquawkAllocator implements SquawkAllocatorInterface
     public function allocate(string $callsign, array $details): ?SquawkAssignmentInterface
     {
         if (!isset($details['origin'])) {
-            Log::error('Origin not provided for airfield pairing squawk allocation', [$callsign, $details]);
+            Log::error(
+                'Origin not provided for airfield pairing squawk allocation',
+                [$callsign, $details]
+            );
             return null;
         }
 
         if (!isset($details['destination'])) {
-            Log::error('Destination not provided for airfield pairing squawk allocation', [$callsign, $details]);
+            Log::error(
+                'Destination not provided for airfield pairing squawk allocation',
+                [$callsign, $details]
+            );
             return null;
         }
 
         $assignment = null;
-        $this->getPossibleRangesForFlight($details['origin'], $details['destination'])->each(
-            function (AirfieldPairingSquawkRange $range) use (&$assignment, $callsign) {
-                $allSquawks = $range->getAllSquawksInRange();
-                $possibleSquawks = $allSquawks->diff(
-                    AirfieldPairingSquawkAssignment::whereIn('code', $allSquawks)->pluck('code')->all()
-                );
+        AirfieldPairingSquawkRange::getConnectionResolver()->connection()->transaction(
+            function () use (&$assignment, $callsign, $details) {
+                $this->getPossibleRangesForFlight(
+                    $details['origin'],
+                    $details['destination']
+                )->each(
+                    function (AirfieldPairingSquawkRange $range) use (&$assignment, $callsign) {
+                        // Lock the range to prevent additional inserts on this range
+                        AirfieldPairingSquawkRange::lockForUpdate()->find($range->id);
 
-                if ($possibleSquawks->isEmpty()) {
-                    return true;
-                }
+                        $allSquawks = $range->getAllSquawksInRange();
+                        $possibleSquawks = $allSquawks->diff(
+                            AirfieldPairingSquawkAssignment::whereIn('code', $allSquawks)
+                                ->pluck('code')
+                                ->all()
+                        );
 
-                NetworkAircraft::firstOrCreate(
-                    [
-                        'callsign' => $callsign,
-                    ]
-                );
+                        if ($possibleSquawks->isEmpty()) {
+                            return true;
+                        }
 
-                $assignment = AirfieldPairingSquawkAssignment::create(
-                    [
-                        'callsign' => $callsign,
-                        'code' => $possibleSquawks->first(),
-                    ]
+                        NetworkAircraft::firstOrCreate(
+                            [
+                                'callsign' => $callsign,
+                            ]
+                        );
+
+                        $assignment = AirfieldPairingSquawkAssignment::create(
+                            [
+                                'callsign' => $callsign,
+                                'code' => $possibleSquawks->first(),
+                            ]
+                        );
+                        return false;
+                    }
                 );
-                return false;
-            });
+            }
+        );
 
         return $assignment;
     }

--- a/app/Allocator/Squawk/General/AirfieldPairingSquawkAllocator.php
+++ b/app/Allocator/Squawk/General/AirfieldPairingSquawkAllocator.php
@@ -9,6 +9,7 @@ use App\Models\Squawk\AirfieldPairing\AirfieldPairingSquawkAssignment;
 use App\Models\Squawk\AirfieldPairing\AirfieldPairingSquawkRange;
 use App\Models\Vatsim\NetworkAircraft;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
 class AirfieldPairingSquawkAllocator implements SquawkAllocatorInterface
@@ -39,7 +40,7 @@ class AirfieldPairingSquawkAllocator implements SquawkAllocatorInterface
         }
 
         $assignment = null;
-        AirfieldPairingSquawkRange::getConnectionResolver()->connection()->transaction(
+        DB::transaction(
             function () use (&$assignment, $callsign, $details) {
                 $this->getPossibleRangesForFlight(
                     $details['origin'],

--- a/app/Allocator/Squawk/General/CcamsSquawkAllocator.php
+++ b/app/Allocator/Squawk/General/CcamsSquawkAllocator.php
@@ -8,13 +8,14 @@ use App\Allocator\Squawk\SquawkAssignmentInterface;
 use App\Models\Squawk\Ccams\CcamsSquawkAssignment;
 use App\Models\Squawk\Ccams\CcamsSquawkRange;
 use App\Models\Vatsim\NetworkAircraft;
+use Illuminate\Support\Facades\DB;
 
 class CcamsSquawkAllocator implements SquawkAllocatorInterface
 {
     public function allocate(string $callsign, array $details): ?SquawkAssignmentInterface
     {
         $assignment = null;
-        CcamsSquawkRange::getConnectionResolver()->connection()->transaction(
+        DB::transaction(
             function () use (&$assignment, $callsign) {
                 CcamsSquawkRange::all()->shuffle()->each(
                     function (CcamsSquawkRange $range) use (&$assignment, $callsign) {

--- a/app/Allocator/Squawk/General/OrcamSquawkAllocator.php
+++ b/app/Allocator/Squawk/General/OrcamSquawkAllocator.php
@@ -9,6 +9,7 @@ use App\Models\Squawk\Orcam\OrcamSquawkAssignment;
 use App\Models\Squawk\Orcam\OrcamSquawkRange;
 use App\Models\Vatsim\NetworkAircraft;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
 class OrcamSquawkAllocator implements SquawkAllocatorInterface
@@ -42,7 +43,7 @@ class OrcamSquawkAllocator implements SquawkAllocatorInterface
         }
 
         $assignment = null;
-        OrcamSquawkRange::getConnectionResolver()->connection()->transaction(
+        DB::transaction(
             function () use (&$assignment, $callsign, $details) {
                 $this->getPossibleRangesForFlight($details['origin'])->each(
                     function (OrcamSquawkRange $range) use (&$assignment, $callsign) {

--- a/app/Allocator/Squawk/Local/UnitDiscreteSquawkAllocator.php
+++ b/app/Allocator/Squawk/Local/UnitDiscreteSquawkAllocator.php
@@ -11,6 +11,7 @@ use App\Models\Squawk\UnitDiscrete\UnitDiscreteSquawkRangeGuest;
 use App\Models\Vatsim\NetworkAircraft;
 use App\Services\ControllerService;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
 class UnitDiscreteSquawkAllocator implements SquawkAllocatorInterface
@@ -20,19 +21,21 @@ class UnitDiscreteSquawkAllocator implements SquawkAllocatorInterface
         $ranges = UnitDiscreteSquawkRange::with('rules')
             ->whereIn('unit', $this->getApplicableUnits($unit))
             ->get();
-        return $ranges->filter(function (UnitDiscreteSquawkRange $range) use ($details) {
-            if ($range->rules->isEmpty()) {
+        return $ranges->filter(
+            function (UnitDiscreteSquawkRange $range) use ($details) {
+                if ($range->rules->isEmpty()) {
+                    return true;
+                }
+
+                foreach ($range->rules as $rule) {
+                    if (!$rule->rule->passes('', $details)) {
+                        return false;
+                    }
+                }
+
                 return true;
             }
-
-            foreach ($range->rules as $rule) {
-                if (!$rule->rule->passes('', $details)) {
-                    return false;
-                }
-            }
-
-            return true;
-        });
+        );
     }
 
     private function getApplicableUnits(string $unit): array
@@ -47,7 +50,9 @@ class UnitDiscreteSquawkAllocator implements SquawkAllocatorInterface
 
     public function allocate(string $callsign, array $details): ?SquawkAssignmentInterface
     {
-        $unit = isset($details['unit']) ? ControllerService::getControllerFacilityFromCallsign($details['unit']) : null;
+        $unit = isset($details['unit']) ? ControllerService::getControllerFacilityFromCallsign(
+            $details['unit']
+        ) : null;
         if (!$unit) {
             Log::error('Unit not provided for local squawk assignment');
             return null;
@@ -60,42 +65,46 @@ class UnitDiscreteSquawkAllocator implements SquawkAllocatorInterface
 
         $assignment = null;
 
-        UnitDiscreteSquawkRange::getConnectionResolver()->connection()->transaction(function () use (&$assignment, $callsign, $details, $unit) {
-            $this->getApplicableRanges($unit, $details)->each(function (UnitDiscreteSquawkRange $range) use (
-                &$assignment,
-                $callsign
-            ) {
-                // Lock the range to prevent duplicate inserts
-                UnitDiscreteSquawkRange::lockForUpdate()->find($range->id);
+        DB::transaction(
+            function () use (&$assignment, $callsign, $details, $unit) {
+                $this->getApplicableRanges($unit, $details)->each(
+                    function (UnitDiscreteSquawkRange $range) use (
+                        &$assignment,
+                        $callsign
+                    ) {
+                        // Lock the range to prevent duplicate inserts
+                        UnitDiscreteSquawkRange::lockForUpdate()->find($range->id);
 
-                $allSquawks = $range->getAllSquawksInRange();
-                $possibleSquawks = $allSquawks->diff(
-                    UnitDiscreteSquawkAssignment::whereIn('code', $allSquawks)
-                        ->where('unit', $range->unit)
-                        ->pluck('code')
-                        ->all()
+                        $allSquawks = $range->getAllSquawksInRange();
+                        $possibleSquawks = $allSquawks->diff(
+                            UnitDiscreteSquawkAssignment::whereIn('code', $allSquawks)
+                                ->where('unit', $range->unit)
+                                ->pluck('code')
+                                ->all()
+                        );
+
+                        if ($possibleSquawks->isEmpty()) {
+                            return true;
+                        }
+
+                        NetworkAircraft::firstOrCreate(
+                            [
+                                'callsign' => $callsign,
+                            ]
+                        );
+
+                        $assignment = UnitDiscreteSquawkAssignment::create(
+                            [
+                                'callsign' => $callsign,
+                                'unit' => $range->unit,
+                                'code' => $possibleSquawks->first(),
+                            ]
+                        );
+                        return false;
+                    }
                 );
-
-                if ($possibleSquawks->isEmpty()) {
-                    return true;
-                }
-
-                NetworkAircraft::firstOrCreate(
-                    [
-                        'callsign' => $callsign,
-                    ]
-                );
-
-                $assignment = UnitDiscreteSquawkAssignment::create(
-                    [
-                        'callsign' => $callsign,
-                        'unit' => $range->unit,
-                        'code' => $possibleSquawks->first(),
-                    ]
-                );
-                return false;
-            });
-        });
+            }
+        );
 
         return $assignment;
     }

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -7,10 +7,13 @@ use App\Events\HoldUnassignedEvent;
 use App\Events\NetworkAircraftDisconnectedEvent;
 use App\Events\NetworkAircraftUpdatedEvent;
 use App\Events\SquawkAssignmentEvent;
+use App\Events\SquawkUnassignedEvent;
 use App\Listeners\Network\RecordFirEntry;
 use App\Listeners\Hold\RecordHoldAssignment;
 use App\Listeners\Hold\RecordHoldUnassignment;
 use App\Listeners\Hold\UnassignHoldOnDisconnect;
+use App\Listeners\Squawk\MarkAssignmentDeletedOnDisconnect;
+use App\Listeners\Squawk\MarkAssignmentDeletedOnUnassignment;
 use App\Listeners\Squawk\RecordSquawkAssignmentHistory;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
@@ -25,6 +28,9 @@ class EventServiceProvider extends ServiceProvider
         SquawkAssignmentEvent::class => [
             RecordSquawkAssignmentHistory::class,
         ],
+        SquawkUnassignedEvent::class => [
+            MarkAssignmentDeletedOnUnassignment::class,
+        ],
         HoldAssignedEvent::class => [
             RecordHoldAssignment::class,
         ],
@@ -33,6 +39,7 @@ class EventServiceProvider extends ServiceProvider
         ],
         NetworkAircraftDisconnectedEvent::class => [
             UnassignHoldOnDisconnect::class,
+            MarkAssignmentDeletedOnDisconnect::class,
         ],
         NetworkAircraftUpdatedEvent::class => [
             RecordFirEntry::class,

--- a/app/Services/NetworkDataService.php
+++ b/app/Services/NetworkDataService.php
@@ -56,7 +56,7 @@ class NetworkDataService
     private function handleTimeouts(): void
     {
         NetworkAircraft::all()->each(function (NetworkAircraft $aircraft) {
-            if ($aircraft->updated_at < Carbon::now()->subMinutes(10)) {
+            if ($aircraft->updated_at < Carbon::now()->subMinutes(20)) {
                 $aircraft->delete();
                 event(new NetworkAircraftDisconnectedEvent($aircraft));
             }

--- a/database/seeds/NetworkAircraftTableSeeder.php
+++ b/database/seeds/NetworkAircraftTableSeeder.php
@@ -56,7 +56,7 @@ class NetworkAircraftTableSeeder extends Seeder
                     'planned_flighttype' => 'I',
                     'planned_route' => 'DIRECT',
                     'created_at' => Carbon::now()->subMinutes(31),
-                    'updated_at' => Carbon::now()->subMinutes(10),
+                    'updated_at' => Carbon::now()->subMinutes(21),
                 ],
             ]
         );


### PR DESCRIPTION
Fix #198 

- Stops squawk integrity violations from happening by locking the ranges during an insert.
- Registers missing events for audit purposes.