### PR TITLE
374 heathrow terminal fallback

### DIFF
--- a/.docker/web/Dockerfile
+++ b/.docker/web/Dockerfile
@@ -1,0 +1,65 @@
+FROM php:7.4-fpm
+
+WORKDIR /var/www/ukcp
+
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    libfreetype6-dev \
+    libonig-dev \
+    libzip-dev \
+    locales \
+    zip \
+    jpegoptim optipng pngquant gifsicle \
+    vim \
+    unzip \
+    git \
+    curl \
+    supervisor \
+    nginx
+
+# Clear cache
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install extensions
+RUN docker-php-ext-install pdo_mysql mbstring zip exif pcntl gd
+
+# Setup PHP ini things for CLI
+RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
+COPY ./usr/local/etc/php/conf.d/local.ini /usr/local/etc/php/conf.d/local.ini
+
+# Install composer
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+# Add user for laravel application and websockets
+RUN groupadd -g 1000 www
+RUN useradd -u 1000 -ms /bin/bash -g www www
+
+# Setup nginx directories
+RUN mkdir -p /var/log/nginx
+RUN touch /var/log/nginx/access.log
+RUN touch /var/log/nginx/error.log
+RUN chown www:www /var/log/nginx
+RUN chown www:www /var/log/nginx/*
+
+RUN mkdir -p /var/lib/nginx
+RUN chown www:www /var/lib/nginx
+
+RUN mkdir -p /run
+RUN touch /run/nginx.pid
+RUN chown www:www /run/nginx.pid
+
+# Make the supervisor directories
+RUN mkdir -p /var/log/supervisor
+RUN chown www:www /var/log/supervisor
+RUN mkdir -p /etc/supervisor
+
+# Copy supervisor scripts
+COPY ./etc/supervisor /etc/supervisor/
+
+# Change current user to www
+USER www
+
+# Expose port 9000 and start php-fpm server
+EXPOSE 9000
+CMD ["/usr/bin/supervisord"]

--- a/.docker/web/etc/nginx/conf.d/ukcp.conf
+++ b/.docker/web/etc/nginx/conf.d/ukcp.conf
@@ -1,0 +1,25 @@
+server {
+    listen 80;
+    listen 443;
+    listen [::]:80;
+    listen [::]:443;
+    error_log  /var/log/nginx/error.log;
+    access_log /var/log/nginx/access.log;
+    root /var/www/ukcp/public;
+    index index.php index.html;
+    server_name ukcp.devapp www.ukcp.devapp;
+
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+
+    location ~ \.php$ {
+        try_files $uri =404;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass web:9000;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+    }
+}

--- a/.docker/web/etc/nginx/nginx.conf
+++ b/.docker/web/etc/nginx/nginx.conf
@@ -1,0 +1,4 @@
+worker_processes 2;
+events {
+    pid /tmp/nginx.pid
+}

--- a/.docker/web/etc/supervisor/conf.d/nginx.conf
+++ b/.docker/web/etc/supervisor/conf.d/nginx.conf
@@ -1,0 +1,6 @@
+[program:nginx]
+command=/usr/sbin/nginx -g "daemon off;"
+numprocs=1
+autostart=true
+autorestart=true
+user=www

--- a/.docker/web/etc/supervisor/conf.d/php-fpm.conf
+++ b/.docker/web/etc/supervisor/conf.d/php-fpm.conf
@@ -1,0 +1,6 @@
+[program:php-fpm]
+command=php-fpm
+numprocs=1
+autostart=true
+autorestart=true
+user=www

--- a/.docker/web/etc/supervisor/conf.d/websockets.conf
+++ b/.docker/web/etc/supervisor/conf.d/websockets.conf
@@ -1,0 +1,6 @@
+[program:websockets]
+command=php /var/www/ukcp/artisan websockets:serve --debug
+numprocs=1
+autostart=true
+autorestart=true
+user=www

--- a/.docker/web/etc/supervisor/supervisord.conf
+++ b/.docker/web/etc/supervisor/supervisord.conf
@@ -1,0 +1,18 @@
+[supervisord]
+logfile = /tmp/supervisord.log
+logfile_maxbytes = 50MB
+logfile_backups=10
+loglevel = info
+pidfile = /tmp/supervisord.pid
+nodaemon = true
+minfds = 1024
+minprocs = 200
+umask = 022
+identifier = supervisor
+directory = /tmp
+nocleanup = true
+childlogdir = /tmp
+strip_ansi = false
+
+[include]
+files = conf.d/*

--- a/.docker/web/usr/local/etc/php/conf.d/local.ini
+++ b/.docker/web/usr/local/etc/php/conf.d/local.ini
@@ -1,0 +1,1 @@
+memory_limit=512M

--- a/.env.example
+++ b/.env.example
@@ -9,10 +9,10 @@ LOG_CHANNEL=custom
 
 # Database
 DB_CONNECTION=mysql
-DB_HOST=127.0.0.1
+DB_HOST=mysql
 DB_PORT=3306
 DB_DATABASE=uk_plugin
-DB_USERNAME=homestead
+DB_USERNAME=root
 DB_PASSWORD=secret
 
 # Caching

--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -20,7 +20,7 @@ return [
             'app_id' => env('PUSHER_APP_ID', 'ukcpwebsocket'),
             'options' => [
                 'cluster' => env('PUSHER_APP_CLUSTER'),
-                'encrypted' => true,
+                'encrypted' =>  env('APP_ENV') !== 'local',
                 'host' => env('WEBSOCKET_BROADCAST_HOST', '127.0.0.1'),
                 'port' => 6001,
                 'scheme' => env('WEBSOCKET_ENV', 'https'),

--- a/database/migrations/2021_01_11_204954_add_heathrow_terminals.php
+++ b/database/migrations/2021_01_11_204954_add_heathrow_terminals.php
@@ -1,0 +1,136 @@
+<?php
+
+use Carbon\Carbon;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+class AddHeathrowTerminals extends Migration
+{
+    /**
+     * Run the migrations.cre
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // Get the heathrow ID
+        $heathrow = DB::table('airfield')
+            ->where('code', 'EGLL')
+            ->first()
+            ->id;
+
+        // Assign Swiss to Stand 218 for instances where someone takes an A330 to Heathrow
+        $stand218 = DB::table('stands')
+            ->where('airfield_id', $heathrow)
+            ->where('identifier', '218')
+            ->first()
+            ->id;
+
+        $swiss = DB::table('airlines')
+            ->where('icao_code', 'SWR')
+            ->first()
+            ->id;
+
+        DB::table('airline_stand')->insert(
+            [
+                'stand_id' => $stand218,
+                'airline_id' => $swiss,
+                'created_at' => Carbon::now(),
+            ]
+        );
+
+        // Create Heathrow terminals
+        $terminal2a = $this->createTerminal($heathrow, 'EGLL_T2A', 'Heathrow Terminal 2A');
+        $terminal2b = $this->createTerminal($heathrow, 'EGLL_T2B', 'Heathrow Terminal 2B');
+        $terminal3 = $this->createTerminal($heathrow, 'EGLL_T3', 'Heathrow Terminal 3');
+        $terminal4 = $this->createTerminal($heathrow, 'EGLL_T4', 'Heathrow Terminal 4');
+        $terminal5a = $this->createTerminal($heathrow, 'EGLL_T5A', 'Heathrow Terminal 5A');
+        $terminal5b = $this->createTerminal($heathrow, 'EGLL_T5B', 'Heathrow Terminal 5B');
+        $terminal5c = $this->createTerminal($heathrow, 'EGLL_T5C', 'Heathrow Terminal 5C');
+
+        // Assign stands to a given terminal
+        $this->assignStandsToTerminal($heathrow, $terminal2a, '216');
+        $this->assignStandsToTerminal($heathrow, $terminal2a, '217');
+        $this->assignStandsToTerminal($heathrow, $terminal2a, '218%');
+        $this->assignStandsToTerminal($heathrow, $terminal2a, '219');
+        $this->assignStandsToTerminal($heathrow, $terminal2a, '22%');
+        $this->assignStandsToTerminal($heathrow, $terminal2b, '23%');
+        $this->assignStandsToTerminal($heathrow, $terminal2b, '24%');
+        $this->assignStandsToTerminal($heathrow, $terminal3, '3%');
+        $this->assignStandsToTerminal($heathrow, $terminal4, '41%');
+        $this->assignStandsToTerminal($heathrow, $terminal4, '42%');
+        $this->assignStandsToTerminal($heathrow, $terminal5a, '50%');
+        $this->assignStandsToTerminal($heathrow, $terminal5a, '51%');
+        $this->assignStandsToTerminal($heathrow, $terminal5a, '52%');
+        $this->assignStandsToTerminal($heathrow, $terminal5b, '53%');
+        $this->assignStandsToTerminal($heathrow, $terminal5b, '54%');
+        $this->assignStandsToTerminal($heathrow, $terminal5c, '55%');
+        $this->assignStandsToTerminal($heathrow, $terminal5c, '56%');
+
+        // Assign airlines to their terminals
+        $this->assignAirlinesToTerminal($terminal2a);
+        $this->assignAirlinesToTerminal($terminal2b);
+        $this->assignAirlinesToTerminal($terminal3);
+        $this->assignAirlinesToTerminal($terminal4);
+        $this->assignAirlinesToTerminal($terminal5a);
+        $this->assignAirlinesToTerminal($terminal5b);
+        $this->assignAirlinesToTerminal($terminal5c);
+    }
+
+    private function createTerminal(int $airfieldId, string $key, string $description): int
+    {
+        return DB::table('terminals')
+            ->insertGetId(
+                [
+                    'airfield_id' => $airfieldId,
+                    'key' => $key,
+                    'description' => $description,
+                    'created_at' => Carbon::now(),
+                ]
+            );
+    }
+
+    private function assignStandsToTerminal(int $airfieldId, string $standIdentifierPattern, int $terminalId): void
+    {
+        DB::table('stands')
+            ->where('airfield_id', $airfieldId)
+            ->where('identifier', 'like', $standIdentifierPattern)
+            ->update(['terminal_id' => $terminalId, 'updated_at' => Carbon::now()]);
+    }
+
+    private function assignAirlinesToTerminal(int $terminalId): void
+    {
+        // Don't add terminals for BA.
+        $airlinesAtTerminal = DB::table('airline_stand')
+            ->join('stands', 'airline_stand.stand_id', '=', 'stands.id')
+            ->join('airlines', 'airline_stand.airline_id', '=', 'airlines.id')
+            ->where('stand.terminal_id', $terminalId)
+            ->whereNotIn('airlines.icao_code', ['BAW', 'SHT', 'IBE', 'IBS'])
+            ->select('airline_stand.id')
+            ->distinct()
+            ->get()
+            ->toArray();
+
+        $formattedAirlines = [];
+        foreach ($airlinesAtTerminal as $airline) {
+            $formattedAirlines[] = [
+                'airline_id' => $airline,
+                'terminal_id' => $terminalId,
+                'created_at' => Carbon::now(),
+            ];
+        }
+
+        DB::table('airline_terminal')
+            ->insert($formattedAirlines);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/database/migrations/2021_01_11_204954_add_heathrow_terminals.php
+++ b/database/migrations/2021_01_11_204954_add_heathrow_terminals.php
@@ -57,6 +57,7 @@ class AddHeathrowTerminals extends Migration
         $this->assignStandsToTerminal($heathrow, $terminal2b, '23%');
         $this->assignStandsToTerminal($heathrow, $terminal2b, '24%');
         $this->assignStandsToTerminal($heathrow, $terminal3, '3%');
+        $this->assignStandsToTerminal($heathrow, $terminal4, '40%');
         $this->assignStandsToTerminal($heathrow, $terminal4, '41%');
         $this->assignStandsToTerminal($heathrow, $terminal4, '42%');
         $this->assignStandsToTerminal($heathrow, $terminal5a, '50%');
@@ -79,7 +80,7 @@ class AddHeathrowTerminals extends Migration
 
     private function createTerminal(int $airfieldId, string $key, string $description): int
     {
-        return DB::table('terminals')
+        return (int) DB::table('terminals')
             ->insertGetId(
                 [
                     'airfield_id' => $airfieldId,
@@ -90,7 +91,7 @@ class AddHeathrowTerminals extends Migration
             );
     }
 
-    private function assignStandsToTerminal(int $airfieldId, string $standIdentifierPattern, int $terminalId): void
+    private function assignStandsToTerminal(int $airfieldId, int $terminalId, string $standIdentifierPattern): void
     {
         DB::table('stands')
             ->where('airfield_id', $airfieldId)
@@ -104,9 +105,9 @@ class AddHeathrowTerminals extends Migration
         $airlinesAtTerminal = DB::table('airline_stand')
             ->join('stands', 'airline_stand.stand_id', '=', 'stands.id')
             ->join('airlines', 'airline_stand.airline_id', '=', 'airlines.id')
-            ->where('stand.terminal_id', $terminalId)
+            ->where('stands.terminal_id', $terminalId)
             ->whereNotIn('airlines.icao_code', ['BAW', 'SHT', 'IBE', 'IBS'])
-            ->select('airline_stand.id')
+            ->select('airline_stand.airline_id')
             ->distinct()
             ->get()
             ->toArray();
@@ -114,7 +115,7 @@ class AddHeathrowTerminals extends Migration
         $formattedAirlines = [];
         foreach ($airlinesAtTerminal as $airline) {
             $formattedAirlines[] = [
-                'airline_id' => $airline,
+                'airline_id' => $airline->airline_id,
                 'terminal_id' => $terminalId,
                 'created_at' => Carbon::now(),
             ];

--- a/database/migrations/2021_01_11_204954_add_heathrow_terminals.php
+++ b/database/migrations/2021_01_11_204954_add_heathrow_terminals.php
@@ -101,7 +101,7 @@ class AddHeathrowTerminals extends Migration
 
     private function assignAirlinesToTerminal(int $terminalId): void
     {
-        // Don't add terminals for BA.
+        // Don't add terminals for BA - they use two terminals, which confuses things.
         $airlinesAtTerminal = DB::table('airline_stand')
             ->join('stands', 'airline_stand.stand_id', '=', 'stands.id')
             ->join('airlines', 'airline_stand.airline_id', '=', 'airlines.id')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,50 @@
+version: "3.9"
+services:
+  # Webserver running PHP-FPM and nginx
+  web:
+    build:
+      context: ./.docker/web
+      dockerfile: Dockerfile
+    container_name: web
+    restart: unless-stopped
+    working_dir: /var/www
+    extra_hosts:
+      - "ukcp.devapp:127.0.0.1"
+    ports:
+      - "80:80"
+      - "443:443"
+      - "6001:6001"
+    volumes:
+      - type: bind
+        source: .
+        target: /var/www/ukcp
+      - ./.docker/web/etc/nginx/conf.d:/etc/nginx/conf.d
+    networks:
+      - ukcp-network
+
+  # Database
+  mysql:
+    image: mysql:8.0
+    container_name: mysql
+    restart: unless-stopped
+    command: --default-authentication-plugin=mysql_native_password
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysqldata:/var/lib/mysql
+    environment:
+      MYSQL_DATABASE: uk_plugin
+      MYSQL_ROOT_PASSWORD: secret
+      MYSQL_AUTHENTICATION_PLUGIN: mysql_native_password
+    networks:
+      - ukcp-network
+
+# Netwokring
+networks:
+  ukcp-network:
+    driver: bridge
+
+#Volumes
+volumes:
+  mysqldata:
+    driver: local

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,13 +14,22 @@ The API is built on [Laravel Framework](https://laravel.com/) and uses [PHPUnit]
 
 ## System Requirements
 
-- PHP 7.3+
+- PHP 7.4+
 - MySQL 8.0
 
 # Local Deployment
 
-It is recommended that you use the [laravel/homestead](https://laravel.com/docs/homestead) Vagrant machine when developing
-the API. For this you will need Vagrant installed [More Information](https://www.vagrantup.com/downloads.html).
+A development environment using `docker-compose` comes bundled with the source, to use it simply run `docker-compose build`
+followed by `docker-compose up`.
+
+## Connecting To The Development Database
+
+The development database binds to Port 3306 and can be connected to using the password provided in
+the `docker-compose.yml`.
+
+## Running The Websocket Server
+
+The websocket service is automatically started on Port 6001.
 
 ## Setup Steps
 


### PR DESCRIPTION
Fix #374 
Uses #369 

Creates terminals, assigns airlines and stands to them at Heathrow so that if specific airline stands aren't available, they get parked at the correct terminal.