### PR TITLE
Stand allocation fun

### DIFF
--- a/app/Allocator/Stand/AbstractArrivalStandAllocator.php
+++ b/app/Allocator/Stand/AbstractArrivalStandAllocator.php
@@ -40,7 +40,7 @@ abstract class AbstractArrivalStandAllocator implements ArrivalStandAllocatorInt
      * Base query for stands at the arrival airfield, which are of a suitable
      * size (or max size if no type) for the aircraft and not occupied.
      */
-    final private function getArrivalAirfieldStandQuery(NetworkAircraft $aircraft): Builder
+    private function getArrivalAirfieldStandQuery(NetworkAircraft $aircraft): Builder
     {
         $aircraftType = Aircraft::where('code', $aircraft->aircraftType)->first();
 
@@ -58,7 +58,7 @@ abstract class AbstractArrivalStandAllocator implements ArrivalStandAllocatorInt
      * @param NetworkAircraft $aircraft
      * @return Collection|Stand[]
      */
-    final private function getPossibleStands(NetworkAircraft $aircraft): Collection
+    private function getPossibleStands(NetworkAircraft $aircraft): Collection
     {
         $orderedQuery = $this->getOrderedStandsQuery($this->getArrivalAirfieldStandQuery($aircraft), $aircraft);
         return $orderedQuery === null
@@ -74,7 +74,7 @@ abstract class AbstractArrivalStandAllocator implements ArrivalStandAllocatorInt
      * @param Builder $query
      * @return Builder
      */
-    final private function applyBaseOrderingToStandsQuery(Builder $query): Builder
+    private function applyBaseOrderingToStandsQuery(Builder $query): Builder
     {
         return $query->orderByWeight()->inRandomOrder();
     }

--- a/app/Allocator/Stand/AbstractArrivalStandAllocator.php
+++ b/app/Allocator/Stand/AbstractArrivalStandAllocator.php
@@ -3,7 +3,6 @@
 namespace App\Allocator\Stand;
 
 use App\Models\Aircraft\Aircraft;
-use App\Models\Aircraft\WakeCategory;
 use App\Models\Stand\Stand;
 use App\Models\Stand\StandAssignment;
 use App\Models\Vatsim\NetworkAircraft;

--- a/app/Allocator/Stand/AirlineArrivalStandAllocator.php
+++ b/app/Allocator/Stand/AirlineArrivalStandAllocator.php
@@ -4,7 +4,7 @@ namespace App\Allocator\Stand;
 
 use App\Models\Vatsim\NetworkAircraft;
 use App\Services\AirlineService;
-use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Builder;
 
 class AirlineArrivalStandAllocator extends AbstractArrivalStandAllocator
 {
@@ -15,17 +15,11 @@ class AirlineArrivalStandAllocator extends AbstractArrivalStandAllocator
         $this->airlineService = $airlineService;
     }
 
-    protected function getPossibleStands(NetworkAircraft $aircraft): Collection
+    protected function getOrderedStandsQuery(Builder $stands, NetworkAircraft $aircraft): ?Builder
     {
         $airline = $this->airlineService->getAirlineForAircraft($aircraft);
-        if ($airline === null) {
-            return new Collection();
-        }
-
-        return $this->getArrivalAirfieldStandQuery($aircraft)
-            ->airline($airline)
-            ->orderByRaw('airline_stand.destination IS NULL DESC')
-            ->inRandomOrder()
-            ->get();
+        return $airline === null
+            ? null
+            : $stands->airline($airline)->orderByRaw('airline_stand.destination IS NULL DESC');
     }
 }

--- a/app/Allocator/Stand/AirlineDestinationArrivalStandAllocator.php
+++ b/app/Allocator/Stand/AirlineDestinationArrivalStandAllocator.php
@@ -2,10 +2,9 @@
 
 namespace App\Allocator\Stand;
 
-use App\Models\Stand\Stand;
 use App\Models\Vatsim\NetworkAircraft;
 use App\Services\AirlineService;
-use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Builder;
 
 class AirlineDestinationArrivalStandAllocator extends AbstractArrivalStandAllocator
 {
@@ -16,20 +15,17 @@ class AirlineDestinationArrivalStandAllocator extends AbstractArrivalStandAlloca
         $this->airlineService = $airlineService;
     }
 
-    protected function getPossibleStands(NetworkAircraft $aircraft): Collection
+    protected function getOrderedStandsQuery(Builder $stands, NetworkAircraft $aircraft): ?Builder
     {
         $airline = $this->airlineService->getAirlineForAircraft($aircraft);
         if ($airline === null) {
-            return new Collection();
+            return null;
         }
 
-        return $this->getArrivalAirfieldStandQuery($aircraft)
-            ->with('airlines')
+        return $stands->with('airlines')
             ->airlineDestination($airline, $this->getDestinationStrings($aircraft))
             ->orderByRaw('airline_stand.destination IS NOT NULL')
-            ->orderByRaw('LENGTH(airline_stand.destination) DESC')
-            ->inRandomOrder()
-            ->get();
+            ->orderByRaw('LENGTH(airline_stand.destination) DESC');
     }
 
     public function getDestinationStrings(NetworkAircraft $aircraft): array

--- a/app/Allocator/Stand/AirlineTerminalArrivalStandAllocator.php
+++ b/app/Allocator/Stand/AirlineTerminalArrivalStandAllocator.php
@@ -4,29 +4,23 @@ namespace App\Allocator\Stand;
 
 use App\Models\Vatsim\NetworkAircraft;
 use App\Services\AirlineService;
-use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Builder;
 
 class AirlineTerminalArrivalStandAllocator extends AbstractArrivalStandAllocator
 {
-    /**
-     * @var AirlineService
-     */
-    private $airlineService;
+    private AirlineService $airlineService;
 
     public function __construct(AirlineService $airlineService)
     {
         $this->airlineService = $airlineService;
     }
 
-    protected function getPossibleStands(NetworkAircraft $aircraft): Collection
+    protected function getOrderedStandsQuery(Builder $stands, NetworkAircraft $aircraft): ?Builder
     {
         if (($airline = $this->airlineService->getAirlineForAircraft($aircraft)) === null) {
-            return new Collection();
+            return null;
         }
 
-        return $this->getArrivalAirfieldStandQuery($aircraft)
-            ->airlineTerminal($airline)
-            ->inRandomOrder()
-            ->get();
+        return $stands->airlineTerminal($airline);
     }
 }

--- a/app/Allocator/Stand/CargoArrivalStandAllocator.php
+++ b/app/Allocator/Stand/CargoArrivalStandAllocator.php
@@ -4,32 +4,26 @@ namespace App\Allocator\Stand;
 
 use App\Models\Vatsim\NetworkAircraft;
 use App\Services\AirlineService;
-use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Builder;
 
 class CargoArrivalStandAllocator extends AbstractArrivalStandAllocator
 {
-    /**
-     * @var AirlineService
-     */
-    private $airlineService;
+    private AirlineService $airlineService;
 
     public function __construct(AirlineService $airlineService)
     {
         $this->airlineService = $airlineService;
     }
 
-    protected function getPossibleStands(NetworkAircraft $aircraft): Collection
+    protected function getOrderedStandsQuery(Builder $stands, NetworkAircraft $aircraft): ?Builder
     {
         if (
             ($airline = $this->airlineService->getAirlineForAircraft($aircraft)) === null ||
             !$airline->is_cargo
         ) {
-            return new Collection();
+            return null;
         }
 
-        return $this->getArrivalAirfieldStandQuery($aircraft)
-            ->cargo()
-            ->inRandomOrder()
-            ->get();
+        return $stands->cargo();
     }
 }

--- a/app/Allocator/Stand/DomesticInternationalStandAllocator.php
+++ b/app/Allocator/Stand/DomesticInternationalStandAllocator.php
@@ -4,21 +4,18 @@ namespace App\Allocator\Stand;
 
 use App\Models\Vatsim\NetworkAircraft;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Str;
 
 class DomesticInternationalStandAllocator extends AbstractArrivalStandAllocator
 {
-    protected function getPossibleStands(NetworkAircraft $aircraft): Collection
+    protected function getOrderedStandsQuery(Builder $stands, NetworkAircraft $aircraft): ?Builder
     {
         if (!$aircraft->planned_depairport) {
-            return new Collection();
+            return null;
         }
 
-        return $this->getDomesticInternationalScope($aircraft, $this->getArrivalAirfieldStandQuery($aircraft))
-            ->generalUse()
-            ->inRandomOrder()
-            ->get();
+        return $this->getDomesticInternationalScope($aircraft, $stands)
+            ->generalUse();
     }
 
     protected function getDomesticInternationalScope(NetworkAircraft $aircraft, Builder $builder): Builder

--- a/app/Allocator/Stand/FallbackArrivalStandAllocator.php
+++ b/app/Allocator/Stand/FallbackArrivalStandAllocator.php
@@ -3,33 +3,12 @@
 namespace App\Allocator\Stand;
 
 use App\Models\Vatsim\NetworkAircraft;
-use App\Services\AirlineService;
-use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Builder;
 
 class FallbackArrivalStandAllocator extends AbstractArrivalStandAllocator
 {
-    /**
-     * @var AirlineService
-     */
-    private $airlineService;
-
-    public function __construct(AirlineService $airlineService)
+    protected function getOrderedStandsQuery(Builder $stands, NetworkAircraft $aircraft): ?Builder
     {
-        $this->airlineService = $airlineService;
-    }
-
-    /**
-     * This runs the base query, and gets stands at the arrival airport suitable
-     * for the aircraft's size that aren't occupied. It's a last ditch attempt.
-     *
-     * @param NetworkAircraft $aircraft
-     * @return Collection
-     */
-    protected function getPossibleStands(NetworkAircraft $aircraft): Collection
-    {
-        return $this->getArrivalAirfieldStandQuery($aircraft)
-            ->notCargo()
-            ->inRandomOrder()
-            ->get();
+        return $stands->notCargo();
     }
 }

--- a/app/Allocator/Stand/GeneralUseArrivalStandAllocator.php
+++ b/app/Allocator/Stand/GeneralUseArrivalStandAllocator.php
@@ -3,34 +3,11 @@
 namespace App\Allocator\Stand;
 
 use App\Models\Vatsim\NetworkAircraft;
-use App\Services\AirlineService;
-use Illuminate\Database\Eloquent\Collection;
-
+use Illuminate\Database\Eloquent\Builder;
 class GeneralUseArrivalStandAllocator extends AbstractArrivalStandAllocator
 {
-    /**
-     * @var AirlineService
-     */
-    private $airlineService;
-
-    public function __construct(AirlineService $airlineService)
+    protected function getOrderedStandsQuery(Builder $stands, NetworkAircraft $aircraft): ?Builder
     {
-        $this->airlineService = $airlineService;
-    }
-
-    /**
-     * This runs the base query, and gets stands at the arrival airport suitable
-     * for the aircraft's size that aren't occupied and available for general use.
-     *
-     * @param NetworkAircraft $aircraft
-     * @return Collection
-     */
-    protected function getPossibleStands(NetworkAircraft $aircraft): Collection
-    {
-        return $this->getArrivalAirfieldStandQuery($aircraft)
-            ->generalUse()
-            ->notCargo()
-            ->inRandomOrder()
-            ->get();
+        return $stands->generalUse()->notCargo();
     }
 }

--- a/app/Allocator/Stand/GeneralUseArrivalStandAllocator.php
+++ b/app/Allocator/Stand/GeneralUseArrivalStandAllocator.php
@@ -4,6 +4,7 @@ namespace App\Allocator\Stand;
 
 use App\Models\Vatsim\NetworkAircraft;
 use Illuminate\Database\Eloquent\Builder;
+
 class GeneralUseArrivalStandAllocator extends AbstractArrivalStandAllocator
 {
     protected function getOrderedStandsQuery(Builder $stands, NetworkAircraft $aircraft): ?Builder

--- a/app/Allocator/Stand/ReservedArrivalStandAllocator.php
+++ b/app/Allocator/Stand/ReservedArrivalStandAllocator.php
@@ -2,14 +2,14 @@
 
 namespace App\Allocator\Stand;
 
+use App\Models\Stand\Stand;
 use App\Models\Stand\StandReservation;
 use App\Models\Vatsim\NetworkAircraft;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Collection;
 
 class ReservedArrivalStandAllocator extends AbstractArrivalStandAllocator
 {
-    protected function getPossibleStands(NetworkAircraft $aircraft): Collection
+    protected function getOrderedStandsQuery(Builder $stands, NetworkAircraft $aircraft): ?Builder
     {
         $reservation = StandReservation::with('stand')
             ->whereHas('stand', function (Builder $standQuery) {
@@ -19,6 +19,8 @@ class ReservedArrivalStandAllocator extends AbstractArrivalStandAllocator
             ->active()
             ->first();
 
-        return $reservation ? new Collection([$reservation->stand]) : new Collection();
+        return $reservation
+            ? Stand::where('stands.id', $reservation->stand_id)
+            : null;
     }
 }

--- a/app/Allocator/Stand/ReservedArrivalStandAllocator.php
+++ b/app/Allocator/Stand/ReservedArrivalStandAllocator.php
@@ -20,7 +20,7 @@ class ReservedArrivalStandAllocator extends AbstractArrivalStandAllocator
             ->first();
 
         return $reservation
-            ? Stand::where('stands.id', $reservation->stand_id)
+            ? Stand::where('stands.id', $reservation->stand_id)->select('stands.*')
             : null;
     }
 }

--- a/database/migrations/2021_02_18_210430_assign_shuttle_stands_to_ba_domestic.php
+++ b/database/migrations/2021_02_18_210430_assign_shuttle_stands_to_ba_domestic.php
@@ -1,0 +1,44 @@
+<?php
+
+use Carbon\Carbon;
+use Illuminate\Database\Migrations\Migration;
+
+class AssignShuttleStandsToBaDomestic extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $stands = DB::table('stands')
+            ->join('airline_stand', 'stands.id', '=', 'airline_stand.stand_id')
+            ->join('airlines', 'airline_stand.airline_id', '=', 'airlines.id')
+            ->where('airlines.icao_code', 'SHT')
+            ->where('airfield_id', DB::table('airfield')->where('code', 'EGLL')->first()->id)
+            ->pluck('stands.id');
+
+        $ba = DB::table('airlines')->where('icao_code', 'BAW')->first()->id;
+        $formattedStands = $stands->map(function (int $standId) use ($ba) {
+            return [
+                'airline_id' => $ba,
+                'stand_id' => $standId,
+                'destination' => 'EG',
+                'created_at' => Carbon::now(),
+            ];
+        })->toArray();
+
+        DB::table('airline_stand')->insert($formattedStands);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+
+    }
+}

--- a/database/migrations/2021_02_18_210430_assign_shuttle_stands_to_ba_domestic.php
+++ b/database/migrations/2021_02_18_210430_assign_shuttle_stands_to_ba_domestic.php
@@ -39,6 +39,5 @@ class AssignShuttleStandsToBaDomestic extends Migration
      */
     public function down()
     {
-
     }
 }


### PR DESCRIPTION
- Apply wake-based stand allocation preference after any bespoke ones. Not doing this caused lots of BA flights to prefer T3 instead of T5 at Heathrow.
- Mark all SHT stands at LL as available to BAW with an origin of `EG`