### PR TITLE
Scaffold data management auth

### DIFF
--- a/app/Console/Commands/DataAdminCreate.php
+++ b/app/Console/Commands/DataAdminCreate.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\UserService;
+use Illuminate\Console\Command;
+
+class DataAdminCreate extends Command
+{
+    protected $signature = 'user:create-data-admin';
+
+    protected $description = 'Command used to generate a user and return user with data admin scope';
+
+    public function handle(UserService $userService)
+    {
+        $token = $userService->createDataAdminUser();
+        $this->info("Data admin user created successfully");
+        $this->line($token);
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -21,6 +21,7 @@ use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 use App\Console\Commands\DeleteExpiredTokens;
 use App\Console\Commands\DeleteUserTokens;
 use App\Console\Commands\CreateUserToken;
+use App\Console\Commands\DataAdminCreate;
 
 class Kernel extends ConsoleKernel
 {
@@ -49,6 +50,7 @@ class Kernel extends ConsoleKernel
         AllocateStandForArrival::class,
         StandReservationsImport::class,
         RecatCategoriesImport::class,
+        DataAdminCreate::class
     ];
 
     /**

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -60,6 +60,11 @@ class Kernel extends HttpKernel
             MiddlewareKeys::SCOPES . ':' . AuthServiceProvider::SCOPE_DEPENDENCY_ADMIN,
             MiddlewareKeys::ADMIN_LOG,
         ],
+        'admin.data' => [
+            MiddlewareKeys::AUTH . ':api',
+            MiddlewareKeys::SCOPES . ':' . AuthServiceProvider::SCOPE_DATA_ADMIN,
+            MiddlewareKeys::ADMIN_LOG,
+        ],
         'admin.github' => [
             MiddlewareKeys::GITHUB_AUTH,
         ],

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -13,18 +13,21 @@ class AuthServiceProvider extends ServiceProvider
     const SCOPE_USER_ADMIN = 'user-admin';
     const SCOPE_VERSION_ADMIN = 'version-admin';
     const SCOPE_DEPENDENCY_ADMIN = 'dependency-admin';
+    const SCOPE_DATA_ADMIN = 'data-admin';
 
     const AUTH_SCOPES = [
         self::SCOPE_USER => 'Can perform plugin user functions',
         self::SCOPE_USER_ADMIN => 'Can perform user administration functions',
         self::SCOPE_VERSION_ADMIN => 'Can perform plugin version administration functions',
         self::SCOPE_DEPENDENCY_ADMIN => 'Can perform dependency administration functions',
+        self::SCOPE_DATA_ADMIN => 'Can administer live data stored in the system'
     ];
 
     const ADMIN_SCOPES = [
         self::SCOPE_USER_ADMIN,
         self::SCOPE_DEPENDENCY_ADMIN,
         self::SCOPE_VERSION_ADMIN,
+        self::SCOPE_DATA_ADMIN
     ];
 
     /**

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -108,7 +108,7 @@ class UserService
     }
 
     /**
-     * Creates a user with the scope of data administration, 
+     * Creates a user with the scope of data administration,
      * returning the token of the user.
      *
      * @return string
@@ -148,7 +148,7 @@ class UserService
         $user = new User();
         $user->id = $newUserCid;
         $user->status = UserStatus::ACTIVE;
-        $user->save(); 
+        $user->save();
 
         return $user;
     }

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -98,19 +98,27 @@ class UserService
      */
     public function createAdminUser() : string
     {
-        $admins = User::where('id', '<', self::MINIMUM_VATSIM_CID);
-        $newUserCid = $admins->exists() ? $admins->max('id') + 1 : 0;
-
-        $user = new User();
-        $user->id = $newUserCid;
-        $user->status = UserStatus::ACTIVE;
-        $user->save();
-
-        return $user->createToken(
+        return $this->createAdminUserModel()->createToken(
             'access',
             [
                 AuthServiceProvider::SCOPE_USER_ADMIN,
                 AuthServiceProvider::SCOPE_VERSION_ADMIN,
+            ]
+        )->accessToken;
+    }
+
+    /**
+     * Creates a user with the scope of data administration, 
+     * returning the token of the user.
+     *
+     * @return string
+     */
+    public function createDataAdminUser() : string
+    {
+        return $this->createAdminUserModel()->createToken(
+            'access',
+            [
+                AuthServiceProvider::SCOPE_DATA_ADMIN
             ]
         )->accessToken;
     }
@@ -125,5 +133,23 @@ class UserService
     public function getUser(int $userCid) : User
     {
         return User::findOrFail($userCid);
+    }
+
+    /**
+     * Create a user model as a 'pseudo' admin user.
+     *
+     * @return User
+     */
+    private function createAdminUserModel(): User
+    {
+        $admins = User::where('id', '<', self::MINIMUM_VATSIM_CID);
+        $newUserCid = $admins->exists() ? $admins->max('id') + 1 : 0;
+
+        $user = new User();
+        $user->id = $newUserCid;
+        $user->status = UserStatus::ACTIVE;
+        $user->save(); 
+
+        return $user;
     }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,6 +47,7 @@ The websocket service is automatically started on Port 6001.
 
 - Create a user and generate their API settings file using `php artisan user:create`
 - Create a user an api key that can administer other users by running `php artisan user:create-admin`
+- Create a user and api key that can administer the data by running `php artisan user:create-data-admin`
 - Create a new api key for an existing non-admin user by running `php artisan token:create`
 - Delete all api keys for a user by running `php artisan tokens:delete-user`
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -161,7 +161,7 @@ Route::middleware('admin.dependency')->group(function () {
 });
 
 // Routes for data management.
-Route::middleware('admin.data')->group(function() {
+Route::middleware('admin.data')->group(function () {
     Route::get('dataadmin', 'TeapotController@normalTeapots');
 });
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -160,6 +160,11 @@ Route::middleware('admin.dependency')->group(function () {
         );
 });
 
+// Routes for data management.
+Route::middleware('admin.data')->group(function() {
+    Route::get('dataadmin', 'TeapotController@normalTeapots');
+});
+
 Route::middleware('admin.github')->group(function () {
     Route::post('github', 'GithubController@processGithubWebhook');
 });

--- a/tests/app/Console/Commands/DataAdminCreateTest.php
+++ b/tests/app/Console/Commands/DataAdminCreateTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\BaseFunctionalTestCase;
+use Illuminate\Support\Facades\Artisan;
+
+class DataAdminCreateTest extends BaseFunctionalTestCase
+{
+    const ARTISAN_COMMAND = 'user:create-data-admin';
+
+    public function testItReturnsSuccess()
+    {
+        $this->assertEquals(0, Artisan::call(self::ARTISAN_COMMAND));
+    }
+
+    public function testItCreatesAToken()
+    {
+        Artisan::call(self::ARTISAN_COMMAND);
+        $token = explode(PHP_EOL, Artisan::output())[1];
+        $this->get('/dataadmin', ['Authorization' => 'Bearer ' . $token])->assertStatus(200);
+    }
+}

--- a/tests/app/Services/UserServiceTest.php
+++ b/tests/app/Services/UserServiceTest.php
@@ -105,6 +105,12 @@ class UserServiceTest extends BaseFunctionalTestCase
         $this->makeTestRequest('/useradmin', $accessToken);
     }
 
+    public function testItCreateaDataAdminAccessToken()
+    {
+        $accessToken = $this->service->createDataAdminUser();
+        $this->makeTestRequest('/dataadmin', $accessToken);
+    }
+
     public function testItAVersionAdminAccessToken()
     {
         $accessToken = $this->service->createAdminUser();


### PR DESCRIPTION
This PR adds the concept of a 'data admin' scope to the auth process. This is to facilitate upcoming work where
a separate service will administer the data contained within UKCP.

The motivation for keeping it seperate from existing 'admin' auth is to ensure the other service doesn't have
more responsibility than it needs.
