### PR TITLE
Add endpoint to view airfield stand/s

### DIFF
--- a/app/Http/Controllers/Admin/StandAdminController.php
+++ b/app/Http/Controllers/Admin/StandAdminController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Models\Stand\Stand;
+use Illuminate\Http\Request;
+use App\Models\Airfield\Airfield;
+use Illuminate\Http\JsonResponse;
+use App\Services\StandAdminService;
+use App\Http\Controllers\BaseController;
+
+class StandAdminController extends BaseController
+{
+    private StandAdminService $service;
+
+    public function __construct(StandAdminService $standAdminService)
+    {
+        $this->service = $standAdminService;
+    }
+
+    /**
+     * Get a list of the registered stand types.
+     *
+     * @return JsonResponse
+     */
+    public function getTypes(): JsonResponse
+    {
+        return response()->json(['types' => $this->service::standTypes()]);
+    }
+
+
+    /**
+     * Get list of stands for an airfield.
+     *
+     * @param Airfield $airfield
+     * @return JsonResponse
+     */
+    public function getStandsForAirfield(Airfield $airfield) : JsonResponse
+    {
+        return response()->json(['stands' => $this->service->getStandsByAirfield($airfield)]);
+    }
+
+    /**
+     * Get details of a given stand which exists for an airfield.
+     *
+     * @param Airfield $airfield
+     * @param Stand $stand
+     * @return JsonResponse
+     */
+    public function getStandDetails(Airfield $airfield, Stand $stand): JsonResponse
+    {
+        if ($stand->airfield_id != $airfield->id) {
+            return response()->json(['message' => 'Stand not part of airfield.'], 404);
+        }
+
+        $stand->load(['terminal', 'wakeCategory', 'type', 'airlines']);
+
+        return response()->json(['stand' => $stand]);
+    }
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -60,6 +60,12 @@ class Kernel extends HttpKernel
             MiddlewareKeys::SCOPES . ':' . AuthServiceProvider::SCOPE_DEPENDENCY_ADMIN,
             MiddlewareKeys::ADMIN_LOG,
         ],
+        'admin.data' => [
+            MiddlewareKeys::AUTH . ':api',
+            MiddlewareKeys::SCOPES . ':' . AuthServiceProvider::SCOPE_DATA_ADMIN,
+            MiddlewareKeys::ADMIN_LOG,
+            \Illuminate\Routing\Middleware\SubstituteBindings::class
+        ],
         'admin.github' => [
             MiddlewareKeys::GITHUB_AUTH,
         ],

--- a/app/Models/Airfield/Airfield.php
+++ b/app/Models/Airfield/Airfield.php
@@ -9,9 +9,12 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Location\Coordinate;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class Airfield extends Model implements MinStackDataProviderInterface
 {
+    use HasFactory;
+
     public $timestamps = true;
 
     protected $table = 'airfield';

--- a/app/Models/Stand/Stand.php
+++ b/app/Models/Stand/Stand.php
@@ -16,9 +16,12 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Location\Coordinate;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class Stand extends Model
 {
+    use HasFactory;
+
     const QUERY_AIRLINE_ID_COLUMN = 'airlines.id';
 
     protected $fillable = [

--- a/app/Providers/StandServiceProvider.php
+++ b/app/Providers/StandServiceProvider.php
@@ -1,18 +1,19 @@
 <?php
 namespace App\Providers;
 
-use App\Allocator\Stand\AirlineArrivalStandAllocator;
-use App\Allocator\Stand\AirlineTerminalArrivalStandAllocator;
-use App\Allocator\Stand\AirlineDestinationArrivalStandAllocator;
+use App\Services\StandService;
+use App\Service\StandAdminService;
+use Illuminate\Foundation\Application;
+use Illuminate\Support\ServiceProvider;
+use App\Imports\Stand\StandReservationsImport;
 use App\Allocator\Stand\CargoArrivalStandAllocator;
-use App\Allocator\Stand\DomesticInternationalStandAllocator;
+use App\Allocator\Stand\AirlineArrivalStandAllocator;
 use App\Allocator\Stand\FallbackArrivalStandAllocator;
 use App\Allocator\Stand\ReservedArrivalStandAllocator;
 use App\Allocator\Stand\GeneralUseArrivalStandAllocator;
-use App\Imports\Stand\StandReservationsImport;
-use App\Services\StandService;
-use Illuminate\Foundation\Application;
-use Illuminate\Support\ServiceProvider;
+use App\Allocator\Stand\DomesticInternationalStandAllocator;
+use App\Allocator\Stand\AirlineTerminalArrivalStandAllocator;
+use App\Allocator\Stand\AirlineDestinationArrivalStandAllocator;
 
 class StandServiceProvider extends ServiceProvider
 {
@@ -37,5 +38,6 @@ class StandServiceProvider extends ServiceProvider
         });
 
         $this->app->singleton(StandReservationsImport::class);
+        $this->app->singleton(StandAdminService::class);
     }
 }

--- a/app/Services/StandAdminService.php
+++ b/app/Services/StandAdminService.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Stand\Stand;
+use App\Models\Stand\StandType;
+use App\Models\Airfield\Airfield;
+use Illuminate\Database\Eloquent\Collection;
+
+class StandAdminService 
+{
+    /**
+     * Return a list of stand types.
+     *
+     * @return Collection
+     */
+    public static function standTypes(): Collection
+    {
+        return StandType::all();
+    }
+
+    /**
+     * Get stands by airfield. Query optimised to be used in
+     * index style view.
+     *
+     * @param Airfield $airfield
+     * @return Collection
+     */
+    public function getStandsByAirfield(Airfield $airfield) : Collection
+    {
+        return Stand::with(['type', 'terminal', 'wakeCategory'])->withCount(['airlines'])->where('airfield_id', $airfield->id)->get();
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
             "database/migrations"
         ],
         "psr-4": {
-            "App\\": ["app/" ,"tests/app/"]
+            "App\\": ["app/" ,"tests/app/"],
+            "Database\\Factories\\": "database/factories/"
         }
 
     },

--- a/database/factories/Airfield/AirfieldFactory.php
+++ b/database/factories/Airfield/AirfieldFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Factories\Airfield;
+
+use App\Models\Model;
+use App\Models\Airfield\Airfield;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class AirfieldFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Airfield::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'code' => $this->faker->lexify('EG??'),
+            'latitude' => $this->faker->latitude(),
+            'longitude' => $this->faker->longitude(),
+            'transition_altitude' => 3000,
+            'standard_high' => 1,
+        ];
+    }
+}

--- a/database/factories/Stand/StandFactory.php
+++ b/database/factories/Stand/StandFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Database\Factories\Stand;
+
+use App\Models\Stand\Stand;
+use App\Models\Airfield\Airfield;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class StandFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Stand::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'airfield_id' => Airfield::factory()->create()->id,
+            'identifier' => (string)$this->faker->numberBetween(0, 500),
+            'latitude' => $this->faker->latitude(),
+            'longitude' => $this->faker->longitude(),
+            'wake_category_id' => 1,
+            'general_use' => false
+        ];
+    }
+}

--- a/docs/api/admin-functions.yml
+++ b/docs/api/admin-functions.yml
@@ -1,0 +1,140 @@
+openapi: '3.0.2'
+info:
+  title: UK Controller PLugin API - Admin Functions 
+  version: '1.0'
+components:
+  schemas:
+    StandType:
+      type: object
+      properties:
+        id:
+          type: integer
+        key:
+          type: string
+        created_at:
+          type: string
+        updated_at:
+          type: string
+    Terminal:
+      type: object
+      properties:
+        id:
+          type: integer
+        key:
+          type: string
+        description:
+          type: string
+        created_at:
+          type: string
+        updated_at:
+          type: string
+    StandListItem:
+      type: object
+      properties:
+        id:
+          type: integer
+        airfield_id:
+          type: integer
+        identifier:
+          type: string
+        latitude:
+          type: integer 
+        longitude:
+          type: integer
+        terminal_id:
+          type: integer
+        wake_category_id:
+          type: integer
+        general_use:
+          type: boolean
+        created_at:
+          type: string
+        updated_at:
+          type: string
+        airlines_count:
+          type: integer
+        'type':
+          $ref: '#/components/schemas/StandType'
+        terminal:
+          $ref: '#/components/schemas/Terminal'
+        wake_category:
+          $ref: '#/components/schemas/WakeCategory'
+    WakeCategory:
+      type: object
+      properties:
+        id:
+          type: integer
+        code:
+          type: string
+        description:
+          type: string
+        relative_weighting:
+          type: integer
+      example:
+        id: 3
+        code: "LM"
+        description: "Lower Medium"
+        relative_weighting: 10
+    Airline:
+      properties:
+        icao_code:
+          type: string
+        name:
+          type: string
+        callsign:
+          type: string
+        is_cargo:
+          type: boolean
+        created_at:
+          type: string
+        updated_at:
+          type: string
+    StandDetailed:
+      allOf:
+        - $ref: '#/components/schemas/StandListItem'
+        - type: object
+          properties:
+            airlines:
+              type: array
+              items: 
+                $ref: '#/components/schemas/Airline'
+
+paths:
+  /stand-types:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            'application/json':
+              schema:
+                properties:
+                  types:
+                    type: array
+                    items: 
+                      $ref: '#/components/schemas/StandListItem'
+  /airfield/{icao}/stands:
+    get:
+      description: 'Get a list of stands from their airfield'
+      responses:
+        '200':
+          description: OK
+          content:
+            'application/json':
+              schema:
+                properties:
+                  stands:
+                    type: array 
+                    items:
+                      $ref: '#/components/schemas/StandListItem'
+  /airfield/{icao}/stands/{stand_id}:
+    get:
+      responses:
+        '200':
+          description: OK
+          content: 
+            'application/json':
+              schema:
+                properties:
+                  stand:
+                    $ref: '#/components/schemas/StandDetailed'

--- a/routes/api.php
+++ b/routes/api.php
@@ -160,6 +160,18 @@ Route::middleware('admin.dependency')->group(function () {
         );
 });
 
+// Routes for data management.
+Route::middleware('admin.data')->group(function () {
+    Route::get('dataadmin', 'TeapotController@normalTeapots');
+
+    Route::prefix('admin')->group(function () {
+        Route::get('/airfield/{airfield:code}/stands', 'Admin\\StandAdminController@getStandsForAirfield');
+        Route::get('/airfield/{airfield:code}/stands/{stand}', 'Admin\\StandAdminController@getStandDetails');
+
+        Route::get('/stand-types', 'Admin\\StandAdminController@getTypes');
+    });
+});
+
 Route::middleware('admin.github')->group(function () {
     Route::post('github', 'GithubController@processGithubWebhook');
 });

--- a/tests/app/Http/Controllers/Admin/StandAdminControllerTest.php
+++ b/tests/app/Http/Controllers/Admin/StandAdminControllerTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\BaseApiTestCase;
+use App\Models\Stand\Stand;
+use App\Models\Airfield\Airfield;
+use App\Providers\AuthServiceProvider;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class StandAdminControllerTest extends BaseApiTestCase
+{
+    use DatabaseTransactions;
+
+    protected static $tokenScope = [
+        AuthServiceProvider::SCOPE_DATA_ADMIN,
+    ];
+
+    public function testStandTypesCanBeRetrieved()
+    {
+        $response = $this->makeAuthenticatedApiRequest(self::METHOD_GET, "admin/stand-types");
+
+        $response->assertStatus(200);
+    }
+
+    public function testStandsCanBeRetrievedForAirfield()
+    {
+        $airfield = Airfield::factory()->create();
+        $stand = Stand::factory()->create(['airfield_id' => $airfield->id]);
+
+        $response = $this->makeAuthenticatedApiRequest(self::METHOD_GET, "admin/airfield/{$airfield->code}/stands/{$stand->id}");
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure(['stand']);
+    }
+
+    public function testAirfieldStandCanBeRetrieved()
+    {
+        $airfield = Airfield::factory()->create();
+        $stand = Stand::factory()->create(['airfield_id' => $airfield->id]);
+
+        $response = $this->makeAuthenticatedApiRequest(self::METHOD_GET, "admin/airfield/{$airfield->code}/stands/{$stand->id}");
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure(['stand']);
+    }
+
+    public function testAirfieldsStandsNotFoundWhenStandIsNotPartOfAirfield()
+    {
+        $airfield = Airfield::factory()->create();
+        $stand = Stand::factory()->create();
+
+        $response = $this->makeAuthenticatedApiRequest(self::METHOD_GET, "admin/airfield/{$airfield->code}/stands/{$stand->id}");
+
+        $response->assertStatus(404);
+        $response->assertJson(['message' => 'Stand not part of airfield.']);
+    }
+}

--- a/tests/app/Services/StandAdminServiceTest.php
+++ b/tests/app/Services/StandAdminServiceTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Services;
+
+use App\BaseFunctionalTestCase;
+use App\Models\Stand\StandType;
+use App\Services\StandAdminService;
+
+class StandAdminServiceTest extends BaseFunctionalTestCase
+{
+    private StandAdminService $service;
+
+    public function setUp() : void
+    {
+        parent::setUp();
+
+        $this->service = $this->app->make(StandAdminService::class);
+    }
+
+    public function testItCanListStandTypes()
+    {
+        $standTypes = StandType::all();
+
+        $this->assertEquals($this->service::standTypes(), $standTypes);
+    }
+}


### PR DESCRIPTION
First pass at viewing a list of the stands in an airfield and individual stands in an airfield.

I've kept this small just to make sure I'm getting a good view of the codebase and how it is structured.

I've added a swagger documentation file to help document the responses - I'll form a pipeline at a later date to publish this
in readable form to the repo. For now, it can be chucked into a swagger editor.
