### PR TITLE
Move .env From GitHub to Server

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -106,18 +106,6 @@ jobs:
       - name: Compile Assets
         run: yarn run prod
 
-      #
-      # CONFIGURATION FILES
-      # Create any configuration files, interpolating secrets
-      #
-      - name: Create .env from Secrets value
-        env:
-          ENV_FILE_CONTENTS: ${{ secrets.ENV_FILE_CONTENTS }}
-        run: 'echo "$ENV_FILE_CONTENTS" > .env'
-
-      - name: Update BUGSNAG_APP_VERSION
-        run: 'sed -i "s/^BUGSNAG_APP_VERSION.*$/BUGSNAG_APP_VERSION=$TAG/" .env'
-
       # Not required for deployment
       - name: Remove node_modules
         run: 'rm -rf node_modules'
@@ -150,6 +138,12 @@ jobs:
           script: |
             # Ensure we're working from the current release
             cd $RELEASE_DIRECTORY
+
+            # Symlink .env from root directory
+            ln -s $APPLICATION_ROOT/.env .env
+
+            # Update BUGSNAG_APP_VERSION
+            sed -i "s/^BUGSNAG_APP_VERSION.*$/BUGSNAG_APP_VERSION=$TAG/" .env
 
             # Install application dependencies
             $PHP_PATH /usr/local/bin/composer update --no-interaction --no-dev


### PR DESCRIPTION
Rather than populating the `.env` file within GitHub Actions based on a secret, we'll keep it on the server and symlink it into each release. This gives us a little more flexibility on the control of the file.

_Note: The .env file has been copied to the application root directory on our production server so this PR can be merged without any risks once approved._