### PR TITLE
build(docker): allow running of supervisorctl

### DIFF
--- a/.docker/web/Dockerfile
+++ b/.docker/web/Dockerfile
@@ -61,6 +61,8 @@ RUN chown www:www /run/nginx.pid
 RUN mkdir -p /var/log/supervisor
 RUN chown www:www /var/log/supervisor
 RUN mkdir -p /etc/supervisor
+RUN mkdir -p /run/supervisor
+RUN chown www:www /run/supervisor
 
 # Copy supervisor scripts
 COPY ./etc/supervisor /etc/supervisor/

--- a/.docker/web/etc/supervisor/supervisord.conf
+++ b/.docker/web/etc/supervisor/supervisord.conf
@@ -14,5 +14,14 @@ nocleanup = true
 childlogdir = /tmp
 strip_ansi = false
 
+[unix_http_server]
+file=/run/supervisor/supervisor.sock
+
+[supervisorctl]
+serverurl=unix:///run/supervisor/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory=supervisor.rpcinterface:make_main_rpcinterface
+
 [include]
 files = conf.d/*


### PR DESCRIPTION
Run supervisorctl in docker so we can restart services in dev