### PR TITLE
fix(websocket): Do plugin events before pusher

### DIFF
--- a/app/Broadcaster/PluginEventBroadcaster.php
+++ b/app/Broadcaster/PluginEventBroadcaster.php
@@ -34,8 +34,8 @@ class PluginEventBroadcaster extends Broadcaster
 
     public function broadcast(array $channels, $event, array $payload = [])
     {
-        $this->pusherBroadcaster->broadcast($channels, $event, $payload);
-        unset($payload['socket']);
+        $payloadWithoutSocket = $payload;
+        unset($payloadWithoutSocket['socket']);
         PluginEvent::create(
             [
                 'event' => [
@@ -45,5 +45,6 @@ class PluginEventBroadcaster extends Broadcaster
                 ]
             ]
         );
+        $this->pusherBroadcaster->broadcast($channels, $event, $payload);
     }
 }

--- a/app/Broadcaster/PluginEventBroadcaster.php
+++ b/app/Broadcaster/PluginEventBroadcaster.php
@@ -41,7 +41,7 @@ class PluginEventBroadcaster extends Broadcaster
                 'event' => [
                     'channel' => (string) $channels[0],
                     'event' => $event,
-                    'data' => $payload,
+                    'data' => $payloadWithoutSocket,
                 ]
             ]
         );


### PR DESCRIPTION
To deal with the fact that Pusher is crashing a lot.