### PR TITLE
No release expiries

### DIFF
--- a/app/Events/DepartureReleaseApprovedEvent.php
+++ b/app/Events/DepartureReleaseApprovedEvent.php
@@ -18,7 +18,9 @@ class DepartureReleaseApprovedEvent extends HighPriorityBroadcastEvent
     {
         return [
             'id' => $this->approval->id,
-            'expires_at' => $this->approval->release_expires_at->toDateTimeString(),
+            'expires_at' => $this->approval->release_expires_at
+                ? $this->approval->release_expires_at->toDateTimeString()
+                : null,
             'released_at' => $this->approval->release_valid_from,
         ];
     }

--- a/app/Http/Requests/Release/Departure/ApproveDepartureRelease.php
+++ b/app/Http/Requests/Release/Departure/ApproveDepartureRelease.php
@@ -10,7 +10,7 @@ class ApproveDepartureRelease extends FormRequest
     public function rules()
     {
         return [
-            'expires_in_seconds' => 'required|integer|min:1',
+            'expires_in_seconds' => 'present|nullable|integer|min:1',
             'released_at' => 'present|nullable|date_format:Y-m-d H:i:s',
             'controller_position_id' => [
                 'required',

--- a/app/Jobs/Release/Departure/CancelOutstandingDepartureReleaseRequests.php
+++ b/app/Jobs/Release/Departure/CancelOutstandingDepartureReleaseRequests.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Jobs\Release\Departure;
+
+use App\Events\DepartureReleaseRequestCancelledEvent;
+use App\Jobs\Network\AircraftDisconnectedSubtask;
+use App\Models\Release\Departure\DepartureReleaseRequest;
+use App\Models\Vatsim\NetworkAircraft;
+
+class CancelOutstandingDepartureReleaseRequests implements AircraftDisconnectedSubtask
+{
+    public function perform(NetworkAircraft $aircraft): void
+    {
+        DepartureReleaseRequest::where('callsign', $aircraft->callsign)->each(
+                function (DepartureReleaseRequest $request) {
+                    $request->delete();
+                    event(new DepartureReleaseRequestCancelledEvent($request));
+                }
+            );
+    }
+}

--- a/app/Jobs/Release/Departure/CancelOutstandingDepartureReleaseRequests.php
+++ b/app/Jobs/Release/Departure/CancelOutstandingDepartureReleaseRequests.php
@@ -12,10 +12,10 @@ class CancelOutstandingDepartureReleaseRequests implements AircraftDisconnectedS
     public function perform(NetworkAircraft $aircraft): void
     {
         DepartureReleaseRequest::where('callsign', $aircraft->callsign)->each(
-                function (DepartureReleaseRequest $request) {
+            function (DepartureReleaseRequest $request) {
                     $request->delete();
                     event(new DepartureReleaseRequestCancelledEvent($request));
                 }
-            );
+        );
     }
 }

--- a/app/Jobs/Release/Departure/CancelRequestsForDepartedAircraft.php
+++ b/app/Jobs/Release/Departure/CancelRequestsForDepartedAircraft.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Jobs\Release\Departure;
+
+use App\Services\DepartureReleaseService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+
+class CancelRequestsForDepartedAircraft implements ShouldQueue
+{
+    use Dispatchable, Queueable;
+
+    public function handle(DepartureReleaseService $releaseService): void
+    {
+        $releaseService->cancelReleasesForAirborneAircraft();
+    }
+}

--- a/app/Listeners/Network/NetworkDataUpdated.php
+++ b/app/Listeners/Network/NetworkDataUpdated.php
@@ -3,6 +3,7 @@
 namespace App\Listeners\Network;
 
 use App\Jobs\Hold\RemoveAssignmentsForAircraftLeavingHold;
+use App\Jobs\Release\Departure\CancelRequestsForDepartedAircraft;
 use App\Jobs\Squawk\ReserveActiveSquawks;
 use App\Jobs\Stand\AssignStandsForDeparture;
 use App\Jobs\Stand\OccupyStands;
@@ -22,7 +23,8 @@ class NetworkDataUpdated implements ShouldQueue, ShouldBeUnique
                 new OccupyStands(),
                 new AssignStandsForDeparture(),
                 new ReserveActiveSquawks(),
-                new RemoveAssignmentsForAircraftLeavingHold()
+                new RemoveAssignmentsForAircraftLeavingHold(),
+                new CancelRequestsForDepartedAircraft(),
             ]
         )->dispatch();
         return true;

--- a/app/Models/Controller/ControllerPosition.php
+++ b/app/Models/Controller/ControllerPosition.php
@@ -3,13 +3,15 @@
 namespace App\Models\Controller;
 
 use App\Models\Airfield\Airfield;
-use App\Models\Sid;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class ControllerPosition extends Model
 {
+    use HasFactory;
+
     public $timestamps = true;
 
     protected $hidden = [

--- a/app/Models/Release/Departure/DepartureReleaseRequest.php
+++ b/app/Models/Release/Departure/DepartureReleaseRequest.php
@@ -6,6 +6,7 @@ use App\Models\Controller\ControllerPosition;
 use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -13,7 +14,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 class DepartureReleaseRequest extends Model
 {
-    use SoftDeletes;
+    use SoftDeletes, HasFactory;
 
     const UPDATED_AT = null;
 

--- a/app/Models/Release/Departure/DepartureReleaseRequest.php
+++ b/app/Models/Release/Departure/DepartureReleaseRequest.php
@@ -50,14 +50,14 @@ class DepartureReleaseRequest extends Model
     /**
      * Approve the departure release for a given amount of time.
      */
-    public function approve(int $userId, int $expiresInSeconds, CarbonImmutable $releaseValidFrom): void
+    public function approve(int $userId, ?int $expiresInSeconds, CarbonImmutable $releaseValidFrom): void
     {
         $this->update(
             [
                 'release_valid_from' => $releaseValidFrom,
                 'released_by' => $userId,
                 'released_at' => Carbon::now(),
-                'release_expires_at' => $releaseValidFrom->addSeconds($expiresInSeconds),
+                'release_expires_at' => $expiresInSeconds ? $releaseValidFrom->addSeconds($expiresInSeconds) : null,
             ]
         );
     }

--- a/app/Models/Vatsim/NetworkAircraft.php
+++ b/app/Models/Vatsim/NetworkAircraft.php
@@ -5,6 +5,7 @@ namespace App\Models\Vatsim;
 use App\Models\Stand\Stand;
 use App\Models\Stand\StandAssignment;
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
@@ -12,6 +13,8 @@ use Location\Coordinate;
 
 class NetworkAircraft extends Model
 {
+    use HasFactory;
+
     const AIRCRAFT_TYPE_REGEX = '/^[0-9A-Z]{4}/';
 
     const AIRCRAFT_TYPE_SEPARATOR = '/';

--- a/app/Providers/NetworkServiceProvider.php
+++ b/app/Providers/NetworkServiceProvider.php
@@ -5,6 +5,7 @@ namespace App\Providers;
 use App\Jobs\Hold\UnassignHoldOnDisconnect;
 use App\Jobs\Network\AircraftDisconnected;
 use App\Jobs\Network\DeleteNetworkAircraft;
+use App\Jobs\Release\Departure\CancelOutstandingDepartureReleaseRequests;
 use App\Jobs\Squawk\MarkAssignmentDeletedOnDisconnect;
 use App\Jobs\Stand\TriggerUnassignmentOnDisconnect;
 use App\Listeners\Network\RecordFirEntry;
@@ -39,6 +40,7 @@ class NetworkServiceProvider extends ServiceProvider implements DeferrableProvid
                         $application->make(UnassignHoldOnDisconnect::class),
                         $application->make(MarkAssignmentDeletedOnDisconnect::class),
                         $application->make(TriggerUnassignmentOnDisconnect::class),
+                        $application->make(CancelOutstandingDepartureReleaseRequests::class),
                         $application->make(DeleteNetworkAircraft::class),
                     ])
                 );

--- a/app/Services/DepartureReleaseService.php
+++ b/app/Services/DepartureReleaseService.php
@@ -120,4 +120,19 @@ class DepartureReleaseService
             );
         }
     }
+
+    public function cancelReleasesForAirborneAircraft(): void
+    {
+        $requestsToProcess = DepartureReleaseRequest::query()
+            ->join('network_aircraft', 'network_aircraft.callsign', '=', 'departure_release_requests.callsign')
+            ->where('network_aircraft.groundspeed', '>=', 50)
+            ->where('network_aircraft.altitude', '>=', 1000)
+            ->select('departure_release_requests.*')
+            ->get();
+
+        $requestsToProcess->each(function (DepartureReleaseRequest $request) {
+            $request->delete();
+            event(new DepartureReleaseRequestCancelledEvent($request));
+        });
+    }
 }

--- a/app/Services/DepartureReleaseService.php
+++ b/app/Services/DepartureReleaseService.php
@@ -47,7 +47,7 @@ class DepartureReleaseService
         DepartureReleaseRequest $request,
         int $approvingControllerId,
         int $approvingUserId,
-        int $approvalExpiresInSeconds,
+        ?int $approvalExpiresInSeconds,
         CarbonImmutable $releaseValidFrom
     ): void {
         $this->checkDecisionAllowed($request, $approvingControllerId, 'approve');

--- a/database/factories/Controller/ControllerPositionFactory.php
+++ b/database/factories/Controller/ControllerPositionFactory.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Database\Factories\Controller;
+
+use App\Models\Controller\ControllerPosition;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ControllerPositionFactory extends Factory
+{
+    const CALLSIGNS = [
+        'EGKK_GND',
+        'EGKK_TWR',
+        'EGLL_N_TWR',
+        'EGGD_APP',
+        'ESSEX_APP',
+        'MAN_W_CTR',
+        'LON_CTR',
+        'SCO_CTR',
+        'LON_W_CTR',
+        'EGLL_DEL',
+        'EGSS_R_APP',
+        'EGGX_FSS',
+    ];
+
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = ControllerPosition::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'callsign' => $this->faker->unique()->randomElement(self::CALLSIGNS),
+            'frequency' => 123.450,
+        ];
+    }
+}

--- a/database/factories/Release/Departure/DepartureReleaseRequestFactory.php
+++ b/database/factories/Release/Departure/DepartureReleaseRequestFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Database\Factories\Release\Departure;
+
+use App\Models\Controller\ControllerPosition;
+use App\Models\Release\Departure\DepartureReleaseRequest;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use TestingUtils\Traits\WithSeedUsers;
+
+class DepartureReleaseRequestFactory extends Factory
+{
+    use WithSeedUsers;
+
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = DepartureReleaseRequest::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'callsign' => 'BAW123',
+            'user_id' => $this->activeUser()->id,
+            'controller_position_id' => ControllerPosition::factory()->create()->id,
+            'target_controller_position_id' => ControllerPosition::factory()->create()->id,
+            'expires_at' => Carbon::now()->addMinutes($this->faker->randomDigit()),
+        ];
+    }
+}

--- a/database/factories/Vatsim/NetworkAircraftFactory.php
+++ b/database/factories/Vatsim/NetworkAircraftFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories\Vatsim;
+
+use App\Models\Vatsim\NetworkAircraft;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class NetworkAircraftFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = NetworkAircraft::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'callsign' => $this->faker->word,
+            'transponder_last_updated_at' => Carbon::now(),
+        ];
+    }
+}

--- a/tests/app/Events/DepartureReleaseApprovedEventTest.php
+++ b/tests/app/Events/DepartureReleaseApprovedEventTest.php
@@ -21,7 +21,7 @@ class DepartureReleaseApprovedEventTest extends BaseUnitTestCase
             [
                 'controller_position_id' => 2,
                 'release_expires_at' => Carbon::now()->addMinutes(2),
-                'released_at' => Carbon::now()->addMinute()->toDateTimeString(),
+                'release_valid_from' => Carbon::now()->addMinute(),
             ]
         );
         $this->request->id = 1;
@@ -40,10 +40,21 @@ class DepartureReleaseApprovedEventTest extends BaseUnitTestCase
 
     public function testItHasBroadcastData()
     {
-        $this->request->release_valid_from = Carbon::now()->addMinute();
         $expected = [
             'id' => 1,
             'expires_at' => Carbon::now()->addMinutes(2)->toDateTimeString(),
+            'released_at' => Carbon::now()->addMinute()->toDateTimeString(),
+        ];
+
+        $this->assertEquals($expected, $this->event->broadcastWith());
+    }
+
+    public function testItHasBroadcastWithNoApprovalTime()
+    {
+        $this->request->release_expires_at = null;
+        $expected = [
+            'id' => 1,
+            'expires_at' => null,
             'released_at' => Carbon::now()->addMinute()->toDateTimeString(),
         ];
 

--- a/tests/app/Jobs/Release/Departure/CancelOutstandingDepartureReleaseRequestsTest.php
+++ b/tests/app/Jobs/Release/Departure/CancelOutstandingDepartureReleaseRequestsTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Jobs\Release\Departure;
+
+use App\BaseFunctionalTestCase;
+use App\Events\DepartureReleaseRequestCancelledEvent;
+use App\Models\Release\Departure\DepartureReleaseRequest;
+use App\Models\Vatsim\NetworkAircraft;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Event;
+
+class CancelOutstandingDepartureReleaseRequestsTest extends BaseFunctionalTestCase
+{
+    private CancelOutstandingDepartureReleaseRequests $listener;
+
+    public function setUp() : void
+    {
+        parent::setUp();
+        $this->listener = $this->app->make(CancelOutstandingDepartureReleaseRequests::class);
+        Carbon::setTestNow(Carbon::now());
+        Event::fake();
+    }
+
+    public function testItRemovesOutstandingDepartureReleaseRequests()
+    {
+        $request1 = DepartureReleaseRequest::factory()->create(['callsign' => 'BAW123']);
+        DepartureReleaseRequest::factory()->create(['callsign' => 'BAW456']);
+        $request3 = DepartureReleaseRequest::factory()->create(['callsign' => 'BAW123']);
+
+        $this->listener->perform(NetworkAircraft::find('BAW123'));
+
+        Event::assertDispatched(
+            DepartureReleaseRequestCancelledEvent::class,
+            function (DepartureReleaseRequestCancelledEvent $event) use ($request1) {
+                return $event->broadcastWith() === ['id' => $request1->id];
+            }
+        );
+
+        Event::assertDispatched(
+            DepartureReleaseRequestCancelledEvent::class,
+            function (DepartureReleaseRequestCancelledEvent $event) use ($request3) {
+                return $event->broadcastWith() === ['id' => $request3->id];
+            }
+        );
+
+        $this->assertSoftDeleted($request1);
+        $this->assertSoftDeleted($request3);
+        $this->assertNotNull(DepartureReleaseRequest::where('callsign', 'BAW456')->first());
+    }
+}

--- a/tests/app/Jobs/Release/Departure/CancelRequestsForDepartedAircraftTest.php
+++ b/tests/app/Jobs/Release/Departure/CancelRequestsForDepartedAircraftTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Jobs\Release\Departure;
+
+use App\BaseUnitTestCase;
+use App\Services\DepartureReleaseService;
+use Mockery;
+
+class CancelRequestsForDepartedAircraftTest extends BaseUnitTestCase
+{
+    private CancelRequestsForDepartedAircraft $cancel;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->cancel = $this->app->make(CancelRequestsForDepartedAircraft::class);
+    }
+
+    public function testHandleCallsStandService()
+    {
+        $releaseService = Mockery::mock(DepartureReleaseService::class);
+        $releaseService->expects('cancelReleasesForAirborneAircraft')->withNoArgs()->once();
+        $this->cancel->handle($releaseService);
+    }
+}

--- a/tests/app/Listeners/Network/NetworkDataUpdatedTest.php
+++ b/tests/app/Listeners/Network/NetworkDataUpdatedTest.php
@@ -4,6 +4,7 @@ namespace App\Listeners\Network;
 
 use App\BaseUnitTestCase;
 use App\Jobs\Hold\RemoveAssignmentsForAircraftLeavingHold;
+use App\Jobs\Release\Departure\CancelRequestsForDepartedAircraft;
 use App\Jobs\Squawk\ReserveActiveSquawks;
 use App\Jobs\Stand\AssignStandsForDeparture;
 use App\Jobs\Stand\OccupyStands;
@@ -29,7 +30,8 @@ class NetworkDataUpdatedTest extends BaseUnitTestCase
                 new OccupyStands(),
                 new AssignStandsForDeparture(),
                 new ReserveActiveSquawks(),
-                new RemoveAssignmentsForAircraftLeavingHold()
+                new RemoveAssignmentsForAircraftLeavingHold(),
+                new CancelRequestsForDepartedAircraft()
             ],
         )
             ->once()


### PR DESCRIPTION
- Cancel departure release requests if aircraft disconnected
- Cancel departure release requests if aircraft is now airborne
- Allow departure release requests to have infinite approval time (up until one of the above requirements becomes false)