### PR TITLE
Migrate to GitHub Actions Concurrency

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,21 +6,17 @@ on:
 
 jobs:
   deploy:
-    # Wait for ~3 builds (3m each - see Turnstyle action below) + current build (3m) before timeout.
-    timeout-minutes: 12
     name: Deploy
     runs-on: ubuntu-latest
+    concurrency:
+      group: ukcp-api-deploy
+      cancel-in-progress: false
     steps:
       - name: Checkout Codes
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
           ref: ${{ github.event.client_payload.ref }}
-
-      - name: Wait for current executions to complete (Turnstyle)
-        uses: softprops/turnstyle@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract short commit hash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    concurrency:
+      group: ukcp-api-release
+      cancel-in-progress: true
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,9 @@ jobs:
   test:
     name: PHP ${{ matrix.php }} / Composer ${{ matrix.composer }}
     runs-on: ubuntu-latest
+    concurrency:
+      group: ukcp-api-test-${{ github.ref }}
+      cancel-in-progress: true
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
As per https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/.