### PR TITLE
fix(sectorfile): handle invalid seconds in sectorfile coordinates

### DIFF
--- a/app/Helpers/Sectorfile/Coordinate.php
+++ b/app/Helpers/Sectorfile/Coordinate.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Helpers\Sectorfile;
+
+class Coordinate
+{
+    private string $latitude;
+    private string $longitude;
+
+    public function __construct(string $latitude, string $longitude)
+    {
+        $this->latitude = $latitude;
+        $this->longitude = $longitude;
+    }
+
+    public function getLatitude(): string
+    {
+        return $this->latitude;
+    }
+
+    public function getLongitude(): string
+    {
+        return $this->longitude;
+    }
+
+    public function __toString(): string
+    {
+        return sprintf('%s %s', $this->latitude, $this->longitude);
+    }
+}

--- a/app/Http/Controllers/NavaidController.php
+++ b/app/Http/Controllers/NavaidController.php
@@ -11,11 +11,15 @@ class NavaidController extends BaseController
     public function __invoke(): JsonResponse
     {
         $navaids = Navaid::all()->map(function (Navaid $navaid) {
+            $sectorfileCoordinate = SectorfileService::convertToSectorfileCoordinate(
+                $navaid->latitude,
+                $navaid->longitude
+            );
             return [
                 'id' => $navaid->id,
                 'identifier' => $navaid->identifier,
-                'latitude' => SectorfileService::convertLatitudeToSectorfileFormat($navaid->latitude),
-                'longitude' => SectorfileService::convertLongitudeToSectorfileFormat($navaid->longitude),
+                'latitude' => $sectorfileCoordinate->getLatitude(),
+                'longitude' => $sectorfileCoordinate->getLongitude(),
             ];
         });
         return response()->json($navaids);

--- a/tests/app/Services/SectorfileServiceTest.php
+++ b/tests/app/Services/SectorfileServiceTest.php
@@ -127,23 +127,35 @@ class SectorfileServiceTest extends BaseUnitTestCase
         ];
     }
 
-    public function testItConvertsLatitudeToSectorfileFormat()
+    /**
+     * @dataProvider sectorfileFormatProvider
+     */
+    public function testItConvertsToSectorfileFormat(float $latitude, float $longitude, string $expected)
     {
-        $this->assertEquals('N050.56.44.000', SectorfileService::convertLatitudeToSectorfileFormat(50.9455556));
+        $this->assertSame(
+            $expected,
+            (string) SectorfileService::convertToSectorfileCoordinate($latitude, $longitude)
+        );
     }
 
-    public function testItConvertsLatitudeToSectorfileFormatBelowEquator()
+    public function sectorfileFormatProvider()
     {
-        $this->assertEquals('S050.56.44.000', SectorfileService::convertLatitudeToSectorfileFormat(-50.9455556));
-    }
-
-    public function testItConvertsLongitudeToSectorfileFormat()
-    {
-        $this->assertEquals('E000.15.42.000', SectorfileService::convertLongitudeToSectorfileFormat(0.2616667));
-    }
-
-    public function testItConvertsLongitudeToSectorfileFormatWestOfMeridian()
-    {
-        $this->assertEquals('W000.15.42.000', SectorfileService::convertLongitudeToSectorfileFormat(-0.2616667));
+        return [
+            'North east' => [
+                50.9455556,
+                0.2616667,
+                'N050.56.44.000 E000.15.42.000'
+            ],
+            'South west' => [
+                -50.9455556,
+                -0.2616667,
+                'S050.56.44.000 W000.15.42.000'
+            ],
+            'Sixty seconds' => [
+                50.5205556,
+                -1.3333333,
+                'N050.31.14.000 W001.20.00.000'
+            ],  // This is KATHY
+        ];
     }
 }


### PR DESCRIPTION
It puts 60 seconds instead of increasing the minutes by 1

fix #552