### PR TITLE
556 squawk return value error

### DIFF
--- a/app/Allocator/Squawk/AbstractSquawkAllocator.php
+++ b/app/Allocator/Squawk/AbstractSquawkAllocator.php
@@ -18,7 +18,7 @@ abstract class AbstractSquawkAllocator implements SquawkAllocatorInterface
             return null;
         }
 
-        NetworkDataService::firstOrCreateNetworkAircraft($callsign);
+        NetworkDataService::createPlaceholderAircraft($callsign);
 
         // Loop the possible squawk ranges and possible codes and try to assign one
         foreach ($this->getPossibleSquawkRanges($details) as $range) {

--- a/app/Http/Controllers/HoldController.php
+++ b/app/Http/Controllers/HoldController.php
@@ -71,10 +71,7 @@ class HoldController extends BaseController
         }
 
         $callsign = $request->json('callsign');
-        NetworkDataService::firstOrCreateNetworkAircraft(
-            $callsign,
-            ['callsign' => $callsign]
-        );
+        NetworkDataService::createPlaceholderAircraft($callsign);
         $assignedHold = AssignedHold::updateOrCreate(
             ['callsign' => $callsign],
             [

--- a/app/Models/Vatsim/NetworkAircraft.php
+++ b/app/Models/Vatsim/NetworkAircraft.php
@@ -54,7 +54,6 @@ class NetworkAircraft extends Model
         parent::boot();
         static::creating(function (NetworkAircraft $aircraft) {
             $aircraft->setUpdatedAt(Carbon::now());
-            $aircraft->transponder_last_updated_at = Carbon::now();
         });
 
         static::updating(function (NetworkAircraft $aircraft) {

--- a/app/Services/NetworkDataService.php
+++ b/app/Services/NetworkDataService.php
@@ -179,12 +179,6 @@ class NetworkDataService
 
     public static function createPlaceholderAircraft(string $callsign): NetworkAircraft
     {
-         NetworkAircraft::upsert(
-             [
-                 'callsign' => $callsign,
-             ],
-             ['callsign'],
-         );
-         return NetworkAircraft::find($callsign);
+        return self::createOrUpdateNetworkAircraft($callsign);
     }
 }

--- a/app/Services/NetworkDataService.php
+++ b/app/Services/NetworkDataService.php
@@ -164,44 +164,27 @@ class NetworkDataService
         string $callsign,
         array $details = []
     ): NetworkAircraft {
-        try {
-            $aircraft = NetworkAircraft::updateOrCreate(
-                ['callsign' => $callsign],
-                array_merge(
-                    ['callsign' => $callsign],
-                    $details
-                )
-            );
-            $aircraft->touch();
-        } catch (QueryException $queryException) {
-            if ($queryException->errorInfo[1] !== 1062) {
-                throw $queryException;
-            }
-            $aircraft = NetworkAircraft::find($callsign);
-        }
-
-        return $aircraft;
+        NetworkAircraft::upsert(
+            array_merge(
+                [
+                    'callsign' => $callsign,
+                ],
+                $details
+            ),
+            ['callsign'],
+            array_merge(['callsign'], array_keys($details)),
+        );
+        return NetworkAircraft::find($callsign);
     }
 
-    public static function firstOrCreateNetworkAircraft(
-        string $callsign,
-        array $details = []
-    ): NetworkAircraft {
-        try {
-            $aircraft = NetworkAircraft::firstOrCreate(
-                ['callsign' => $callsign],
-                array_merge(
-                    ['callsign' => $callsign],
-                    $details
-                )
-            );
-        } catch (QueryException $queryException) {
-            if ($queryException->errorInfo[1] !== 1062) {
-                throw $queryException;
-            }
-            $aircraft = NetworkAircraft::find($callsign);
-        }
-
-        return $aircraft;
+    public static function createPlaceholderAircraft(string $callsign): NetworkAircraft
+    {
+         NetworkAircraft::upsert(
+             [
+                 'callsign' => $callsign,
+             ],
+             ['callsign'],
+         );
+         return NetworkAircraft::find($callsign);
     }
 }

--- a/app/Services/StandService.php
+++ b/app/Services/StandService.php
@@ -198,7 +198,7 @@ class StandService
             throw new StandNotFoundException(sprintf('Stand with id %d not found', $standId));
         }
 
-        NetworkDataService::firstOrCreateNetworkAircraft($callsign);
+        NetworkDataService::createPlaceholderAircraft($callsign);
         $currentAssignment = StandAssignment::where('stand_id', $standId)->first();
 
         if ($currentAssignment && $currentAssignment->callsign !== $callsign) {
@@ -223,7 +223,7 @@ class StandService
             throw new StandNotFoundException(sprintf('Stand with id %d not found', $standId));
         }
 
-        NetworkDataService::firstOrCreateNetworkAircraft($callsign);
+        NetworkDataService::createPlaceholderAircraft($callsign);
         $currentAssignment = StandAssignment::with('aircraft', 'stand.pairedStands.assignment')
             ->where('stand_id', $standId)
             ->first();

--- a/database/factories/Vatsim/NetworkAircraftFactory.php
+++ b/database/factories/Vatsim/NetworkAircraftFactory.php
@@ -24,7 +24,7 @@ class NetworkAircraftFactory extends Factory
     {
         return [
             'callsign' => $this->faker->word,
-            'transponder_last_updated_at' => Carbon::now(),
+            'transponder_last_updated_at' => null,
         ];
     }
 }

--- a/database/migrations/2021_06_19_144633_network_aircraft_transponder_updated_at_default.php
+++ b/database/migrations/2021_06_19_144633_network_aircraft_transponder_updated_at_default.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class NetworkAircraftTransponderUpdatedAtDefault extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::statement(
+            'ALTER TABLE `network_aircraft` 
+                  CHANGE `transponder_last_updated_at` `transponder_last_updated_at` TIMESTAMP'
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        DB::statement(
+            'ALTER TABLE `network_aircraft` 
+                  CHANGE `transponder_last_updated_at` `transponder_last_updated_at` TIMESTAMP NOT NULL'
+        );
+    }
+}

--- a/tests/app/Http/Controllers/StandControllerTest.php
+++ b/tests/app/Http/Controllers/StandControllerTest.php
@@ -243,7 +243,7 @@ class StandControllerTest extends BaseApiTestCase
 
     private function addStandAssignment(string $callsign, int $standId)
     {
-        NetworkDataService::firstOrCreateNetworkAircraft($callsign);
+        NetworkDataService::createPlaceholderAircraft($callsign);
         StandAssignment::create(
             [
                 'callsign' => $callsign,

--- a/tests/app/Jobs/Stand/TriggerUnassignmentOnDisconnectTest.php
+++ b/tests/app/Jobs/Stand/TriggerUnassignmentOnDisconnectTest.php
@@ -42,7 +42,7 @@ class TriggerUnassignmentOnDisconnectTest extends BaseFunctionalTestCase
 
     private function addStandAssignment(string $callsign, int $standId): StandAssignment
     {
-        NetworkDataService::firstOrCreateNetworkAircraft($callsign);
+        NetworkDataService::createPlaceholderAircraft($callsign);
         return StandAssignment::create(
             [
                 'callsign' => $callsign,

--- a/tests/app/Services/NetworkDataServiceTest.php
+++ b/tests/app/Services/NetworkDataServiceTest.php
@@ -339,7 +339,7 @@ class NetworkDataServiceTest extends BaseFunctionalTestCase
         $expected->save();
         $expected->refresh();
         $this->assertEquals(
-            $this->filterBySet($expected->toArray()),
+            $expected->toArray(),
             NetworkDataService::createPlaceholderAircraft('AAL123')->toArray()
         );
 
@@ -413,15 +413,5 @@ class NetworkDataServiceTest extends BaseFunctionalTestCase
         }
 
         return $baseData;
-    }
-
-    private function filterBySet(array $data): array
-    {
-        return array_filter(
-            $data,
-            function ($value) {
-                return isset($value);
-            }
-        );
     }
 }

--- a/tests/app/Services/StandServiceTest.php
+++ b/tests/app/Services/StandServiceTest.php
@@ -422,7 +422,7 @@ class StandServiceTest extends BaseFunctionalTestCase
 
     public function testItDoesntOccupyStandsIfAircraftTooHigh()
     {
-        NetworkDataService::firstOrCreateNetworkAircraft(
+        NetworkDataService::createOrUpdateNetworkAircraft(
             'RYR787',
             [
                 'latitude' => 51.47187222,
@@ -443,7 +443,7 @@ class StandServiceTest extends BaseFunctionalTestCase
 
     public function testItRemovesOccupiedStandIfAircraftTooHigh()
     {
-        $aircraft = NetworkDataService::firstOrCreateNetworkAircraft(
+        $aircraft = NetworkDataService::createOrUpdateNetworkAircraft(
             'RYR787',
             [
                 'latitude' => 51.47187222,
@@ -465,7 +465,7 @@ class StandServiceTest extends BaseFunctionalTestCase
 
     public function testItDoesntOccupyStandsIfAircraftTooFast()
     {
-        NetworkDataService::firstOrCreateNetworkAircraft(
+        NetworkDataService::createOrUpdateNetworkAircraft(
             'RYR787',
             [
                 'latitude' => 51.47187222,
@@ -486,7 +486,7 @@ class StandServiceTest extends BaseFunctionalTestCase
 
     public function testItRemovesOccupiedStandIfAircraftTooFast()
     {
-        $aircraft = NetworkDataService::firstOrCreateNetworkAircraft(
+        $aircraft = NetworkDataService::createOrUpdateNetworkAircraft(
             'RYR787',
             [
                 'latitude' => 51.47187222,
@@ -508,7 +508,7 @@ class StandServiceTest extends BaseFunctionalTestCase
 
     public function testItOccupiesAFreshStand()
     {
-        $aircraft = NetworkDataService::firstOrCreateNetworkAircraft(
+        $aircraft = NetworkDataService::createOrUpdateNetworkAircraft(
             'RYR787',
             [
                 'latitude' => 51.47187222,
@@ -524,7 +524,7 @@ class StandServiceTest extends BaseFunctionalTestCase
 
     public function testItHandlesCurrentStandIfStillOccupied()
     {
-        $aircraft = NetworkDataService::firstOrCreateNetworkAircraft(
+        $aircraft = NetworkDataService::createOrUpdateNetworkAircraft(
             'RYR787',
             [
                 'latitude' => 51.47187222,
@@ -541,7 +541,7 @@ class StandServiceTest extends BaseFunctionalTestCase
 
     public function testItDoesntChangeOccupiedStandIfTheAircraftHasMovedLatitudeSinceOccupancy()
     {
-        $aircraft = NetworkDataService::firstOrCreateNetworkAircraft(
+        $aircraft = NetworkDataService::createOrUpdateNetworkAircraft(
             'RYR787',
             [
                 'latitude' => 51.47187222,
@@ -559,7 +559,7 @@ class StandServiceTest extends BaseFunctionalTestCase
 
     public function testItChangesOccupiedStandIfTheAircraftHasMovedLatitudeSinceOccupancy()
     {
-        $aircraft = NetworkDataService::firstOrCreateNetworkAircraft(
+        $aircraft = NetworkDataService::createOrUpdateNetworkAircraft(
             'RYR787',
             [
                 'latitude' => 51.47187222,
@@ -577,7 +577,7 @@ class StandServiceTest extends BaseFunctionalTestCase
 
     public function testItChangesOccupiedStandIfTheAircraftHasMovedLongitudeSinceOccupancy()
     {
-        $aircraft = NetworkDataService::firstOrCreateNetworkAircraft(
+        $aircraft = NetworkDataService::createOrUpdateNetworkAircraft(
             'RYR787',
             [
                 'latitude' => 51.47187222,
@@ -595,7 +595,7 @@ class StandServiceTest extends BaseFunctionalTestCase
 
     public function testItRemovesOccupiedStandIfTheAircraftChangesLatitudeAndIsNoLongerOnStand()
     {
-        $aircraft = NetworkDataService::firstOrCreateNetworkAircraft(
+        $aircraft = NetworkDataService::createOrUpdateNetworkAircraft(
             'RYR787',
             [
                 'latitude' => 53.65883639,
@@ -613,7 +613,7 @@ class StandServiceTest extends BaseFunctionalTestCase
 
     public function testItRemovesOccupiedStandIfTheAircraftChangesLongitudeAndIsNoLongerOnStand()
     {
-        $aircraft = NetworkDataService::firstOrCreateNetworkAircraft(
+        $aircraft = NetworkDataService::createOrUpdateNetworkAircraft(
             'RYR787',
             [
                 'latitude' => 51.47187222,
@@ -632,7 +632,7 @@ class StandServiceTest extends BaseFunctionalTestCase
     public function testItUsurpsAssignedStands()
     {
         $this->expectsEvents(StandUnassignedEvent::class);
-        NetworkDataService::firstOrCreateNetworkAircraft(
+        NetworkDataService::createOrUpdateNetworkAircraft(
             'RYR787',
             [
                 'latitude' => 51.47187222,
@@ -660,7 +660,7 @@ class StandServiceTest extends BaseFunctionalTestCase
             ]
         );
 
-        $aircraft = NetworkDataService::firstOrCreateNetworkAircraft(
+        $aircraft = NetworkDataService::createOrUpdateNetworkAircraft(
             'RYR787',
             [
                 'latitude' => 51.47437111,
@@ -786,7 +786,7 @@ class StandServiceTest extends BaseFunctionalTestCase
             ]
         );
 
-        $aircraft = NetworkDataService::firstOrCreateNetworkAircraft(
+        $aircraft = NetworkDataService::createOrUpdateNetworkAircraft(
             'BMI221',
             [
                 'planned_aircraft' => 'B738',
@@ -806,7 +806,7 @@ class StandServiceTest extends BaseFunctionalTestCase
     public function testItDoesntAllocateStandIfPerformingCircuits()
     {
         $this->doesntExpectEvents(StandAssignedEvent::class);
-        $aircraft = NetworkDataService::firstOrCreateNetworkAircraft(
+        $aircraft = NetworkDataService::createOrUpdateNetworkAircraft(
             'BMI221',
             [
                 'planned_aircraft' => 'B738',
@@ -826,7 +826,7 @@ class StandServiceTest extends BaseFunctionalTestCase
     public function testItDoesntPerformAllocationIfStandTooFarFromAirfield()
     {
         $this->doesntExpectEvents(StandAssignedEvent::class);
-        $aircraft = NetworkDataService::firstOrCreateNetworkAircraft(
+        $aircraft = NetworkDataService::createOrUpdateNetworkAircraft(
             'BMI221',
             [
                 'planned_aircraft' => 'B738',
@@ -845,7 +845,7 @@ class StandServiceTest extends BaseFunctionalTestCase
     public function testItDoesntPerformAllocationIfAircraftHasNoGroundspeed()
     {
         $this->doesntExpectEvents(StandAssignedEvent::class);
-        $aircraft = NetworkDataService::firstOrCreateNetworkAircraft(
+        $aircraft = NetworkDataService::createOrUpdateNetworkAircraft(
             'BMI221',
             [
                 'planned_aircraft' => 'B738',
@@ -869,7 +869,7 @@ class StandServiceTest extends BaseFunctionalTestCase
         });
 
         $this->doesntExpectEvents(StandAssignedEvent::class);
-        $aircraft = NetworkDataService::firstOrCreateNetworkAircraft(
+        $aircraft = NetworkDataService::createOrUpdateNetworkAircraft(
             'BMI221',
             [
                 'planned_aircraft' => 'B738',
@@ -888,7 +888,7 @@ class StandServiceTest extends BaseFunctionalTestCase
     public function testItDoesntPerformAllocationIfStandAlreadyAssigned()
     {
         $this->doesntExpectEvents(StandAssignedEvent::class);
-        $aircraft = NetworkDataService::firstOrCreateNetworkAircraft(
+        $aircraft = NetworkDataService::createOrUpdateNetworkAircraft(
             'BMI221',
             [
                 'planned_aircraft' => 'B738',
@@ -913,7 +913,7 @@ class StandServiceTest extends BaseFunctionalTestCase
     public function testItDoesntReturnAllocationIfAirfieldNotFound()
     {
         $this->doesntExpectEvents(StandAssignedEvent::class);
-        $aircraft = NetworkDataService::firstOrCreateNetworkAircraft(
+        $aircraft = NetworkDataService::createOrUpdateNetworkAircraft(
             'BMI221',
             [
                 'planned_aircraft' => 'B738',
@@ -932,7 +932,7 @@ class StandServiceTest extends BaseFunctionalTestCase
     public function testItDoesntPerformAllocationIfUnknownAircraftType()
     {
         $this->doesntExpectEvents(StandAssignedEvent::class);
-        $aircraft = NetworkDataService::firstOrCreateNetworkAircraft(
+        $aircraft = NetworkDataService::createOrUpdateNetworkAircraft(
             'BMI221',
             [
                 'planned_aircraft' => 'B736',
@@ -953,7 +953,7 @@ class StandServiceTest extends BaseFunctionalTestCase
         Aircraft::where('code', 'B738')->update(['allocate_stands' => false]);
 
         $this->doesntExpectEvents(StandAssignedEvent::class);
-        $aircraft = NetworkDataService::firstOrCreateNetworkAircraft(
+        $aircraft = NetworkDataService::createOrUpdateNetworkAircraft(
             'BMI221',
             [
                 'planned_aircraft' => 'B738',
@@ -1067,7 +1067,7 @@ class StandServiceTest extends BaseFunctionalTestCase
                 'longitude' =>  -6.222070,
             ]
         );
-        $occupier = NetworkDataService::firstOrCreateNetworkAircraft('OCCUPIED');
+        $occupier = NetworkDataService::createPlaceholderAircraft('OCCUPIED');
         $occupier->occupiedStand()->sync($stand4);
 
         // Stand 5 is paired with stand 2 which is assigned
@@ -1239,7 +1239,7 @@ class StandServiceTest extends BaseFunctionalTestCase
     public function testItAssignsOccupiedStandsAtDepartureAirfields()
     {
         $this->expectsEvents(StandAssignedEvent::class);
-        $aircraft = NetworkDataService::firstOrCreateNetworkAircraft(
+        $aircraft = NetworkDataService::createOrUpdateNetworkAircraft(
             'RYR787',
             [
                 'latitude' => 51.47187222,
@@ -1258,7 +1258,7 @@ class StandServiceTest extends BaseFunctionalTestCase
     public function testItUpdatesAssignedOccupiedStandsAtDepartureAirfields()
     {
         $this->expectsEvents(StandAssignedEvent::class);
-        $aircraft = NetworkDataService::firstOrCreateNetworkAircraft(
+        $aircraft = NetworkDataService::createOrUpdateNetworkAircraft(
             'RYR787',
             [
                 'latitude' => 51.47187222,
@@ -1280,7 +1280,7 @@ class StandServiceTest extends BaseFunctionalTestCase
     public function testItDoesntAssignStandsAtNonDepartureAirfields()
     {
         $this->doesntExpectEvents(StandAssignedEvent::class);
-        $aircraft = NetworkDataService::firstOrCreateNetworkAircraft(
+        $aircraft = NetworkDataService::createOrUpdateNetworkAircraft(
             'RYR787',
             [
                 'latitude' => 51.47187222,
@@ -1299,7 +1299,7 @@ class StandServiceTest extends BaseFunctionalTestCase
     public function testItRemovesAssignmentsAtDepartureAirfieldIfStandUnoccupied()
     {
         $this->expectsEvents(StandUnassignedEvent::class);
-        NetworkDataService::firstOrCreateNetworkAircraft(
+        NetworkDataService::createOrUpdateNetworkAircraft(
             'RYR787',
             [
                 'latitude' => 51.47187222,
@@ -1318,7 +1318,7 @@ class StandServiceTest extends BaseFunctionalTestCase
     public function testItDoesntRemoveStandAssignmentsIfNoStandOccupiedButAssignmentNotAtDepartureAirfield()
     {
         $this->doesntExpectEvents(StandUnassignedEvent::class);
-        NetworkDataService::firstOrCreateNetworkAircraft(
+        NetworkDataService::createOrUpdateNetworkAircraft(
             'RYR787',
             [
                 'latitude' => 51.47187222,
@@ -1336,7 +1336,7 @@ class StandServiceTest extends BaseFunctionalTestCase
 
     private function addStandAssignment(string $callsign, int $standId): StandAssignment
     {
-        NetworkDataService::firstOrCreateNetworkAircraft($callsign);
+        NetworkDataService::createPlaceholderAircraft($callsign);
         return StandAssignment::create(
             [
                 'callsign' => $callsign,
@@ -1347,7 +1347,7 @@ class StandServiceTest extends BaseFunctionalTestCase
 
     private function addStandReservation(string $callsign, int $standId, bool $active): StandReservation
     {
-        NetworkDataService::firstOrCreateNetworkAircraft($callsign);
+        NetworkDataService::createPlaceholderAircraft($callsign);
         return StandReservation::create(
             [
                 'callsign' => $callsign,


### PR DESCRIPTION
In a transaction (e.g. when assigning squawks), NetworkDataService can hit an integrity violation on updateOrCreate but then not subsequently find the aircraft in the database. This switches it for an Upsert so it works.