### PR TITLE
refactor(version): mark all versions as deleted upon new release

### DIFF
--- a/app/Services/VersionService.php
+++ b/app/Services/VersionService.php
@@ -158,15 +158,14 @@ class VersionService extends ServiceProvider
         }
 
         // Create the version
-        Version::create(
+        $newVersion = Version::create(
             [
                 'version' => $tag
             ]
         );
 
         // Retire old versions
-        $versionsToKeep = Version::orderBy('id', 'desc')->limit(self::VERSIONS_TO_KEEP)->pluck('id')->toArray();
-        Version::whereNotIn('id', $versionsToKeep)->delete();
+        Version::where('id', '<>', $newVersion->id)->delete();
     }
 
     public function getFullVersionDetails(Version $version): array

--- a/tests/app/Services/VersionServiceTest.php
+++ b/tests/app/Services/VersionServiceTest.php
@@ -188,14 +188,14 @@ class VersionServiceTest extends BaseFunctionalTestCase
             'version',
             [
                 'version' => '2.0.3',
-                'deleted_at' => null,
+                'deleted_at' => Carbon::now(),
             ]
         );
         $this->assertDatabaseHas(
             'version',
             [
                 'version' => '2.0.4',
-                'deleted_at' => null,
+                'deleted_at' => Carbon::now(),
             ]
         );
         $this->assertDatabaseHas(


### PR DESCRIPTION
We dont need to keep them around now due to automatic updates

fix #586