### PR TITLE
test(networkaircraft): add unique constraint on faker for network aircraft

### DIFF
--- a/database/factories/Vatsim/NetworkAircraftFactory.php
+++ b/database/factories/Vatsim/NetworkAircraftFactory.php
@@ -23,7 +23,7 @@ class NetworkAircraftFactory extends Factory
     public function definition()
     {
         return [
-            'callsign' => $this->faker->word,
+            'callsign' => $this->faker->unique()->word,
             'transponder_last_updated_at' => null,
         ];
     }


### PR DESCRIPTION
It was causing an issue with duplicate primary keys

fix #591