### PR TITLE
chore(squawks): update channel island domestic squawk ranges

### DIFF
--- a/database/migrations/2021_07_13_153842_update_channel_island_domestic_squawks.php
+++ b/database/migrations/2021_07_13_153842_update_channel_island_domestic_squawks.php
@@ -1,0 +1,33 @@
+<?php
+
+use Carbon\Carbon;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class UpdateChannelIslandDomesticSquawks extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::table('airfield_pairing_squawk_ranges')
+            ->whereIn('origin', ['EGJA', 'EGJB', 'EGJJ'])
+            ->where('destination', 'EG')
+            ->update(['last' => '1247', 'updated_at' => Carbon::now()]);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}


### PR DESCRIPTION
Part of the range has been taken away for other uses

fix #598