### PR TITLE
fix(network): fix phantom aircraft caused by network aircraft loop

### DIFF
--- a/app/Services/NetworkDataService.php
+++ b/app/Services/NetworkDataService.php
@@ -180,7 +180,7 @@ class NetworkDataService
 
     public static function createPlaceholderAircraft(string $callsign): NetworkAircraft
     {
-        return self::createOrUpdateNetworkAircraft($callsign);
+        return NetworkAircraft::find($callsign) ?? self::createOrUpdateNetworkAircraft($callsign);
     }
 
     private function pilotValid(array $pilot): bool

--- a/tests/app/Services/NetworkDataServiceTest.php
+++ b/tests/app/Services/NetworkDataServiceTest.php
@@ -363,7 +363,7 @@ class NetworkDataServiceTest extends BaseFunctionalTestCase
         $expectedData = $this->getTransformedPilotData('AAL123');
         $expected = NetworkAircraft::create($expectedData);
         $expected->created_at = Carbon::now()->subHours(2);
-        $expected->updated_at = Carbon::now();
+        $expected->updated_at = Carbon::now()->subMinutes(5);
         $expected->save();
         $expected->refresh();
         $this->assertEquals(
@@ -377,7 +377,7 @@ class NetworkDataServiceTest extends BaseFunctionalTestCase
                 $expectedData,
                 [
                     'created_at' => Carbon::now()->subHours(2)->toDateTimeString(),
-                    'updated_at' => Carbon::now()->toDateTimeString(),
+                    'updated_at' => Carbon::now()->subMinutes(5)->toDateTimeString(),
                 ]
             ),
         );


### PR DESCRIPTION
We get in a bit of a loop when creating placeholder aircraft, so lets not do that.