### PR TITLE
fix(networkdata): data races with timing out aircraft

### DIFF
--- a/app/Models/Vatsim/NetworkAircraft.php
+++ b/app/Models/Vatsim/NetworkAircraft.php
@@ -5,6 +5,7 @@ namespace App\Models\Vatsim;
 use App\Models\Stand\Stand;
 use App\Models\Stand\StandAssignment;
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -14,6 +15,8 @@ use Location\Coordinate;
 class NetworkAircraft extends Model
 {
     use HasFactory;
+
+    private const TIME_OUT_MINUTES = 20;
 
     const AIRCRAFT_TYPE_REGEX = '/^[0-9A-Z]{4}/';
 
@@ -60,6 +63,14 @@ class NetworkAircraft extends Model
             if ($aircraft->isDirty('transponder')) {
                 $aircraft->transponder_last_updated_at = Carbon::now();
             }
+        });
+    }
+
+    public static function booted()
+    {
+        parent::booted();
+        static::addGlobalScope('active', function(Builder $builder) {
+            $builder->where('network_aircraft.updated_at', '>', Carbon::now()->subMinutes(self::TIME_OUT_MINUTES));
         });
     }
 
@@ -127,5 +138,10 @@ class NetworkAircraft extends Model
     public function isIfr(): bool
     {
         return $this->planned_flighttype === 'I';
+    }
+
+    public function scopeTimedOut(Builder $builder): Builder
+    {
+        return $builder->where('network_aircraft.updated_at', '<', Carbon::now()->subMinutes(self::TIME_OUT_MINUTES));
     }
 }

--- a/app/Models/Vatsim/NetworkAircraft.php
+++ b/app/Models/Vatsim/NetworkAircraft.php
@@ -69,7 +69,7 @@ class NetworkAircraft extends Model
     public static function booted()
     {
         parent::booted();
-        static::addGlobalScope('active', function(Builder $builder) {
+        static::addGlobalScope('active', function (Builder $builder) {
             $builder->where('network_aircraft.updated_at', '>', Carbon::now()->subMinutes(self::TIME_OUT_MINUTES));
         });
     }

--- a/app/Services/NetworkDataService.php
+++ b/app/Services/NetworkDataService.php
@@ -148,7 +148,8 @@ class NetworkDataService
      */
     private function handleTimeouts(): void
     {
-        NetworkAircraft::where('updated_at', '<', Carbon::now()->subMinutes(20))
+        NetworkAircraft::withoutGlobalScope('active')
+            ->timedOut()
             ->get()
             ->each(
                 function (NetworkAircraft $aircraft) {

--- a/tests/app/Console/Commands/AllocateStandForArrivalTest.php
+++ b/tests/app/Console/Commands/AllocateStandForArrivalTest.php
@@ -21,8 +21,7 @@ class AllocateStandForArrivalTest extends BaseFunctionalTestCase
                 new Collection(
                     [
                         NetworkAircraft::find('BAW123'),
-                        NetworkAircraft::find('BAW456'),
-                        NetworkAircraft::find('BAW789'),
+                        NetworkAircraft::find('BAW456')
                     ]
                 )
             );
@@ -45,16 +44,6 @@ class AllocateStandForArrivalTest extends BaseFunctionalTestCase
         $serviceMock->shouldReceive('removeAllocationIfDestinationChanged')
             ->with(Mockery::on(function (NetworkAircraft $aircraft) {
                 return $aircraft->callsign === 'BAW456';
-            }));
-
-        $serviceMock->shouldReceive('allocateStandForAircraft')
-            ->with(Mockery::on(function (NetworkAircraft $aircraft) {
-                return $aircraft->callsign === 'BAW789';
-            }));
-
-        $serviceMock->shouldReceive('removeAllocationIfDestinationChanged')
-            ->with(Mockery::on(function (NetworkAircraft $aircraft) {
-                return $aircraft->callsign === 'BAW789';
             }));
 
         $this->app->instance(StandService::class, $serviceMock);

--- a/tests/app/Services/NetworkDataServiceTest.php
+++ b/tests/app/Services/NetworkDataServiceTest.php
@@ -256,6 +256,12 @@ class NetworkDataServiceTest extends BaseFunctionalTestCase
     {
         $this->fakeNetworkDataReturn();
         $this->service->updateNetworkData();
+        Queue::assertNotPushed(AircraftDisconnected::class, function (AircraftDisconnected $job) {
+            return $job->aircraft->callsign === 'BAW123';
+        });
+        Queue::assertNotPushed(AircraftDisconnected::class, function (AircraftDisconnected $job) {
+            return $job->aircraft->callsign === 'BAW456 ';
+        });
         Queue::assertPushed(AircraftDisconnected::class, function (AircraftDisconnected $job) {
             return $job->aircraft->callsign === 'BAW789';
         });

--- a/tests/app/Services/SquawkServiceTest.php
+++ b/tests/app/Services/SquawkServiceTest.php
@@ -141,7 +141,8 @@ class SquawkServiceTest extends BaseFunctionalTestCase
             [
                 'callsign' => 'RYR999',
                 'transponder' => '1234',
-                'transponder_last_updated_at' => Carbon::now()->subMinutes(3)
+                'transponder_last_updated_at' => Carbon::now()->subMinutes(3),
+                'updated_at' => Carbon::now(),
             ]
         );
         $this->expectsEvents(SquawkAssignmentEvent::class);
@@ -164,7 +165,8 @@ class SquawkServiceTest extends BaseFunctionalTestCase
             [
                 'callsign' => 'RYR999',
                 'transponder' => '1234',
-                'transponder_last_updated_at' => Carbon::now()->subMinutes(3)
+                'transponder_last_updated_at' => Carbon::now()->subMinutes(3),
+                'updated_at' => Carbon::now(),
             ]
         );
         SquawkAssignment::create(['callsign' => 'RYR999', 'code' => '5678', 'assignment_type' => 'ORCAM']);
@@ -189,12 +191,14 @@ class SquawkServiceTest extends BaseFunctionalTestCase
                 [
                     'callsign' => 'RYR999',
                     'transponder' => '1234',
-                    'transponder_last_updated_at' => Carbon::now()->subMinutes(3)
+                    'transponder_last_updated_at' => Carbon::now()->subMinutes(3),
+                    'updated_at' => Carbon::now(),
                 ],
                 [
                     'callsign' => 'WZZ888',
                     'transponder' => '1234',
-                    'transponder_last_updated_at' => Carbon::now()->subMinutes(3)
+                    'transponder_last_updated_at' => Carbon::now()->subMinutes(3),
+                    'updated_at' => Carbon::now(),
                 ],
             ],
         );
@@ -225,7 +229,8 @@ class SquawkServiceTest extends BaseFunctionalTestCase
                 [
                     'callsign' => 'RYR999',
                     'transponder' => '1234',
-                    'transponder_last_updated_at' => Carbon::now()->subMinute()
+                    'transponder_last_updated_at' => Carbon::now()->subMinute(),
+                    'updated_at' => Carbon::now(),
                 ],
             ],
         );

--- a/tests/app/Services/StandServiceTest.php
+++ b/tests/app/Services/StandServiceTest.php
@@ -1228,8 +1228,7 @@ class StandServiceTest extends BaseFunctionalTestCase
         $this->assertEquals(
             collect(
                 [
-                    NetworkAircraft::find('BAW123'),
-                    NetworkAircraft::find('BAW789')
+                    NetworkAircraft::find('BAW123')
                 ]
             ),
             $this->service->getAircraftEligibleForArrivalStandAllocation()->toBase()


### PR DESCRIPTION
Overlapping jobs post-timeout could cause exceptions due to MySQL foreign key issues. Fix this by adding a global scope to network aircraft so only active ones are selected for querying.

fix #634
fix #555 