### PR TITLE
fix(stands): fix issue with job overlap

### DIFF
--- a/app/Services/StandService.php
+++ b/app/Services/StandService.php
@@ -225,6 +225,7 @@ class StandService
 
         NetworkDataService::createPlaceholderAircraft($callsign);
         $currentAssignment = StandAssignment::with('aircraft', 'stand.pairedStands.assignment')
+            ->whereHas('aircraft')
             ->where('stand_id', $standId)
             ->first();
 


### PR DESCRIPTION
Potential overlaps with aircraft deletion and not eager-loading relations can cause a field to come
out as null

fix #637