### PR TITLE
test(stands): Fix flakey test

### DIFF
--- a/tests/app/Http/Controllers/Admin/StandAdminControllerTest.php
+++ b/tests/app/Http/Controllers/Admin/StandAdminControllerTest.php
@@ -410,7 +410,7 @@ class StandAdminControllerTest extends BaseApiTestCase
     {
         $airfieldWithTerminal = Airfield::factory()->create();
         $terminal = Terminal::factory()->create(['airfield_id' => $airfieldWithTerminal->id]);
-        $stands = Stand::factory()->count(2)->create(['terminal_id' => $terminal->id]);
+        $stands = Stand::factory()->count(2)->create(['terminal_id' => $terminal->id])->fresh();
 
         $response = $this->makeAuthenticatedApiRequest(self::METHOD_GET, "admin/airfields/{$airfieldWithTerminal->code}/terminals/{$terminal->key}/stands");
         


### PR DESCRIPTION
The models are getting inaccurate longitudes - probably because they're returned straight from eloquent and not the db. This refreshes the collection so we get exactly whats in the DB.