### PR TITLE
feat(stands): Allow stands to be temporarily closed

### DIFF
--- a/app/Http/Controllers/Admin/StandAdminController.php
+++ b/app/Http/Controllers/Admin/StandAdminController.php
@@ -168,6 +168,24 @@ class StandAdminController extends BaseController
     }
 
     /**
+     * Open a stand which is contained within a given airfield.
+     *
+     * @param Airfield $airfield
+     * @param Stand $stand
+     * @return JsonResponse
+     */
+    public function openStand(Airfield $airfield, Stand $stand) : JsonResponse
+    {
+        if ($stand->airfield_id != $airfield->id) {
+            return response()->json(self::STAND_NOT_IN_AIRFIELD_ERROR, 404);
+        }
+
+        $stand->open();
+
+        return response()->json([], 204);
+    }
+
+    /**
      * Get a list of terminals for an Airfield if configured.
      *
      * @param Airfield $airfield

--- a/app/Http/Controllers/Admin/StandAdminController.php
+++ b/app/Http/Controllers/Admin/StandAdminController.php
@@ -144,7 +144,25 @@ class StandAdminController extends BaseController
             return response()->json(self::STAND_NOT_IN_AIRFIELD_ERROR, 404);
         }
 
-        $stand->delete();
+        $stand->forceDelete();
+
+        return response()->json([], 204);
+    }
+
+    /**
+     * Close a stand which is contained within a given airfield.
+     *
+     * @param Airfield $airfield
+     * @param Stand $stand
+     * @return JsonResponse
+     */
+    public function closeStand(Airfield $airfield, Stand $stand) : JsonResponse
+    {
+        if ($stand->airfield_id != $airfield->id) {
+            return response()->json(self::STAND_NOT_IN_AIRFIELD_ERROR, 404);
+        }
+
+        $stand->close();
 
         return response()->json([], 204);
     }

--- a/app/Http/Controllers/Admin/StandAdminController.php
+++ b/app/Http/Controllers/Admin/StandAdminController.php
@@ -144,7 +144,7 @@ class StandAdminController extends BaseController
             return response()->json(self::STAND_NOT_IN_AIRFIELD_ERROR, 404);
         }
 
-        $stand->forceDelete();
+        $stand->delete();
 
         return response()->json([], 204);
     }

--- a/app/Models/Stand/Stand.php
+++ b/app/Models/Stand/Stand.php
@@ -15,12 +15,15 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Location\Coordinate;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class Stand extends Model
 {
-    use HasFactory;
+    use HasFactory, SoftDeletes;
+
+    const DELETED_AT = 'closed_at';
 
     const QUERY_AIRLINE_ID_COLUMN = 'airlines.id';
 
@@ -250,5 +253,16 @@ class Stand extends Model
     public function reservationsInNextHour(): HasMany
     {
         return $this->hasMany(StandReservation::class)->upcoming(Carbon::now()->addHour());
+    }
+
+    public function isClosed(): bool
+    {
+        return $this->closed_at !== null;
+    }
+
+    public function close(): Stand
+    {
+        $this->update(['closed_at' => Carbon::now()]);
+        return $this;
     }
 }

--- a/app/Services/StandAdminService.php
+++ b/app/Services/StandAdminService.php
@@ -28,6 +28,10 @@ class StandAdminService
      */
     public function getStandsByAirfield(Airfield $airfield) : Collection
     {
-        return Stand::with(['type', 'terminal', 'wakeCategory'])->withCount(['airlines'])->where('airfield_id', $airfield->id)->get();
+        return Stand::with(['type', 'terminal', 'wakeCategory'])
+            ->withTrashed()
+            ->withCount(['airlines'])
+            ->where('airfield_id', $airfield->id)
+            ->get();
     }
 }

--- a/app/Services/StandAdminService.php
+++ b/app/Services/StandAdminService.php
@@ -29,7 +29,6 @@ class StandAdminService
     public function getStandsByAirfield(Airfield $airfield) : Collection
     {
         return Stand::with(['type', 'terminal', 'wakeCategory'])
-            ->withTrashed()
             ->withCount(['airlines'])
             ->where('airfield_id', $airfield->id)
             ->get();

--- a/app/Services/StandService.php
+++ b/app/Services/StandService.php
@@ -127,8 +127,10 @@ class StandService
             'pairedStands.occupier',
             'pairedStands.activeReservations'
         )
+            ->withTrashed()
             ->airfield($airfield)
             ->get();
+
         $stands->sortBy('identifier', SORT_NATURAL);
 
         $standStatuses = [];
@@ -155,7 +157,10 @@ class StandService
             'max_wake_category' => $stand->wakeCategory ? $stand->wakeCategory->code: null,
             'max_aircraft_type' => $stand->maxAircraft ? $stand->maxAircraft->code : null,
         ];
-        if ($stand->occupier->first()) {
+
+        if ($stand->isClosed()) {
+            $standData['status'] = 'closed';
+        } elseif ($stand->occupier->first()) {
             $standData['status'] = 'occupied';
             $standData['callsign'] = $stand->occupier->first()->callsign;
         } elseif ($stand->assignment) {

--- a/app/Services/StandService.php
+++ b/app/Services/StandService.php
@@ -127,7 +127,6 @@ class StandService
             'pairedStands.occupier',
             'pairedStands.activeReservations'
         )
-            ->withTrashed()
             ->airfield($airfield)
             ->get();
 

--- a/database/migrations/2021_09_10_083341_add_closed_at_to_stands_table.php
+++ b/database/migrations/2021_09_10_083341_add_closed_at_to_stands_table.php
@@ -14,7 +14,7 @@ class AddClosedAtToStandsTable extends Migration
     public function up()
     {
         Schema::table('stands', function (Blueprint $table) {
-            $table->softDeletes('closed_at')->index()->comment('When the stand was closed for use');
+            $table->timestamp('closed_at')->nullable()->index()->comment('When the stand was closed for use');
         });
     }
 

--- a/database/migrations/2021_09_10_083341_add_closed_at_to_stands_table.php
+++ b/database/migrations/2021_09_10_083341_add_closed_at_to_stands_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddClosedAtToStandsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('stands', function (Blueprint $table) {
+            $table->softDeletes('closed_at')->index()->comment('When the stand was closed for use');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('stands', function (Blueprint $table) {
+            $table->dropSoftDeletes('closed_at');
+        });
+    }
+}

--- a/database/migrations/2021_09_10_084143_close_gatwick_pier6_stands.php
+++ b/database/migrations/2021_09_10_084143_close_gatwick_pier6_stands.php
@@ -1,0 +1,31 @@
+<?php
+
+use Carbon\Carbon;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+class CloseGatwickPier6Stands extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::table('stands')
+            ->where('airfield_id', DB::table('airfield')->where('code', 'EGKK')->first()->id)
+            ->whereIn('identifier', ['109', '110', '110L', '110R', '111'])
+            ->update(['closed_at' => Carbon::now(), 'updated_at' => Carbon::now()]);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/docs/admin/admin-functions.yml
+++ b/docs/admin/admin-functions.yml
@@ -401,7 +401,18 @@ paths:
 
   /airfields/{icao}/stands/{stand_id}/close:
     patch:
-      description: Close stands
+      description: Close a given stand so that it will not be assigned be the arrival asigner
+      tags:
+        - "stands"
+      responses:
+        '204':
+          description: 'No content (successful operation)'
+        '404':
+          $ref: '#/components/responses/StandNotInAirfield'
+
+  /airfields/{icao}/stands/{stand_id}/open:
+    patch:
+      description: Open a given stand so that it will be considered by the arrival asigner
       tags:
         - "stands"
       responses:

--- a/docs/admin/admin-functions.yml
+++ b/docs/admin/admin-functions.yml
@@ -51,6 +51,8 @@ components:
           type: string
         updated_at:
           type: string
+        closed_at:
+          type: string
         airlines_count:
           type: integer
         'type':
@@ -389,6 +391,17 @@ paths:
           $ref: '#/components/responses/DuplicateStandIdentifier'
     delete:
       description: Delete stand
+      tags:
+        - "stands"
+      responses:
+        '204':
+          description: 'No content (successful operation)'
+        '404':
+          $ref: '#/components/responses/StandNotInAirfield'
+
+  /airfields/{icao}/stands/{stand_id}/close:
+    patch:
+      description: Close stands
       tags:
         - "stands"
       responses:

--- a/routes/api.php
+++ b/routes/api.php
@@ -197,25 +197,35 @@ Route::middleware('api')->group(
                     function () {
                         Route::prefix('airfields')->group(function () {
                             Route::get('', 'Admin\\StandAdminController@getAirfields');
-                            Route::get('/{airfield:code}/terminals', 'Admin\\StandAdminController@getTerminals');
-                            Route::get('/{airfield:code}/terminals/{terminal:key}/stands', 'Admin\\StandAdminController@getStandsByTerminal');
-                            Route::post('/{airfield:code}/stands', 'Admin\\StandAdminController@createNewStand');
-                            Route::get(
-                                '/{airfield:code}/stands',
-                                'Admin\\StandAdminController@getStandsForAirfield'
-                            );
-                            Route::get(
-                                '/{airfield:code}/stands/{stand}',
-                                'Admin\\StandAdminController@getStandDetails'
-                            );
-                            Route::put(
-                                '/{airfield:code}/stands/{stand}',
-                                'Admin\\StandAdminController@modifyStand'
-                            );
-                            Route::delete(
-                                '/{airfield:code}/stands/{stand}',
-                                'Admin\\StandAdminController@deleteStand'
-                            );
+                            Route::prefix('{airfield:code}')->group(function () {
+                                Route::prefix('terminals')->group(function () {
+                                    Route::get('', 'Admin\\StandAdminController@getTerminals');
+                                    Route::get('{terminal:key}/stands', 'Admin\\StandAdminController@getStandsByTerminal');
+                                });
+                                Route::prefix('stands')->group(function() {
+                                    Route::post('', 'Admin\\StandAdminController@createNewStand');
+                                    Route::get(
+                                        '',
+                                        'Admin\\StandAdminController@getStandsForAirfield'
+                                    );
+                                    Route::get(
+                                        '{stand}',
+                                        'Admin\\StandAdminController@getStandDetails'
+                                    );
+                                    Route::put(
+                                        '{stand}',
+                                        'Admin\\StandAdminController@modifyStand'
+                                    );
+                                    Route::delete(
+                                        '{stand}',
+                                        'Admin\\StandAdminController@deleteStand'
+                                    );
+                                    Route::patch(
+                                        'close',
+                                        'Admin\\StandAdminController@closeStand'
+                                    );
+                                });
+                            });
                         });
 
                         Route::get('/navaids', 'Admin\\NavaidAdminController@getNavaids');

--- a/routes/api.php
+++ b/routes/api.php
@@ -208,26 +208,28 @@ Route::middleware('api')->group(
                                         '',
                                         'Admin\\StandAdminController@getStandsForAirfield'
                                     );
-                                    Route::get(
-                                        '{stand}',
-                                        'Admin\\StandAdminController@getStandDetails'
-                                    );
-                                    Route::put(
-                                        '{stand}',
-                                        'Admin\\StandAdminController@modifyStand'
-                                    );
-                                    Route::delete(
-                                        '{stand}',
-                                        'Admin\\StandAdminController@deleteStand'
-                                    );
-                                    Route::patch(
-                                        'close',
-                                        'Admin\\StandAdminController@closeStand'
-                                    );
-                                    Route::patch(
-                                        'open',
-                                        'Admin\\StandAdminController@openStand'
-                                    );
+                                    Route::prefix('{stand}')->group(function () {
+                                        Route::get(
+                                            '',
+                                            'Admin\\StandAdminController@getStandDetails'
+                                        );
+                                        Route::put(
+                                            '',
+                                            'Admin\\StandAdminController@modifyStand'
+                                        );
+                                        Route::delete(
+                                            '',
+                                            'Admin\\StandAdminController@deleteStand'
+                                        );
+                                        Route::patch(
+                                            'close',
+                                            'Admin\\StandAdminController@closeStand'
+                                        );
+                                        Route::patch(
+                                            'open',
+                                            'Admin\\StandAdminController@openStand'
+                                        );
+                                    });
                                 });
                             });
                         });

--- a/routes/api.php
+++ b/routes/api.php
@@ -224,6 +224,10 @@ Route::middleware('api')->group(
                                         'close',
                                         'Admin\\StandAdminController@closeStand'
                                     );
+                                    Route::patch(
+                                        'open',
+                                        'Admin\\StandAdminController@openStand'
+                                    );
                                 });
                             });
                         });

--- a/routes/api.php
+++ b/routes/api.php
@@ -202,7 +202,7 @@ Route::middleware('api')->group(
                                     Route::get('', 'Admin\\StandAdminController@getTerminals');
                                     Route::get('{terminal:key}/stands', 'Admin\\StandAdminController@getStandsByTerminal');
                                 });
-                                Route::prefix('stands')->group(function() {
+                                Route::prefix('stands')->group(function () {
                                     Route::post('', 'Admin\\StandAdminController@createNewStand');
                                     Route::get(
                                         '',

--- a/tests/app/Http/Controllers/Admin/StandAdminControllerTest.php
+++ b/tests/app/Http/Controllers/Admin/StandAdminControllerTest.php
@@ -375,6 +375,18 @@ class StandAdminControllerTest extends BaseApiTestCase
         ]);
     }
 
+    public function testClosesStand()
+    {
+        $stand = Stand::factory()->create(['airfield_id' => $this->airfield->id]);
+
+        $response = $this->makeAuthenticatedApiRequest(self::METHOD_PATCH, "admin/airfields/{$this->airfield->code}/stands/{$stand->id}/close");
+
+        $response->assertStatus(204);
+
+        $stand->refresh();
+        $this->assertSoftDeleted($stand);
+    }
+
     public function testDoesntDeleteStandWhenNotPartOfAirfield()
     {
         $stand = Stand::factory()->create();

--- a/tests/app/Http/Controllers/Admin/StandAdminControllerTest.php
+++ b/tests/app/Http/Controllers/Admin/StandAdminControllerTest.php
@@ -395,7 +395,7 @@ class StandAdminControllerTest extends BaseApiTestCase
         $response->assertStatus(204);
 
         $stand->refresh();
-        $this->assertSoftDeleted($stand);
+        $this->assertTrue($stand->isClosed());
     }
 
     public function testDoesntCloseStandWhenNotPartOfAirfield()
@@ -406,6 +406,9 @@ class StandAdminControllerTest extends BaseApiTestCase
 
         $response->assertStatus(404);
         $response->assertJson(['message' => 'Stand not part of airfield.']);
+
+        $stand->refresh();
+        $this->assertFalse($stand->isClosed());
     }
 
     public function testOpensStand()
@@ -428,6 +431,8 @@ class StandAdminControllerTest extends BaseApiTestCase
 
         $response->assertStatus(404);
         $response->assertJson(['message' => 'Stand not part of airfield.']);
+
+        $stand->refresh();
         $this->assertTrue($stand->isClosed());
     }
 

--- a/tests/app/Http/Controllers/Admin/StandAdminControllerTest.php
+++ b/tests/app/Http/Controllers/Admin/StandAdminControllerTest.php
@@ -375,6 +375,16 @@ class StandAdminControllerTest extends BaseApiTestCase
         ]);
     }
 
+    public function testDoesntDeleteStandWhenNotPartOfAirfield()
+    {
+        $stand = Stand::factory()->create();
+
+        $response = $this->makeAuthenticatedApiRequest(self::METHOD_DELETE, "admin/airfields/{$this->airfield->code}/stands/{$stand->id}");
+
+        $response->assertStatus(404);
+        $response->assertJson(['message' => 'Stand not part of airfield.']);
+    }
+
     public function testClosesStand()
     {
         $stand = Stand::factory()->create(['airfield_id' => $this->airfield->id]);
@@ -387,11 +397,11 @@ class StandAdminControllerTest extends BaseApiTestCase
         $this->assertSoftDeleted($stand);
     }
 
-    public function testDoesntDeleteStandWhenNotPartOfAirfield()
+    public function testDoesntCloseStandWhenNotPartOfAirfield()
     {
         $stand = Stand::factory()->create();
 
-        $response = $this->makeAuthenticatedApiRequest(self::METHOD_DELETE, "admin/airfields/{$this->airfield->code}/stands/{$stand->id}");
+        $response = $this->makeAuthenticatedApiRequest(self::METHOD_PATCH, "admin/airfields/{$this->airfield->code}/stands/{$stand->id}/close");
 
         $response->assertStatus(404);
         $response->assertJson(['message' => 'Stand not part of airfield.']);

--- a/tests/app/Models/Stand/StandTest.php
+++ b/tests/app/Models/Stand/StandTest.php
@@ -34,7 +34,7 @@ class StandTest extends BaseFunctionalTestCase
         $this->assertEquals([1], $stands);
     }
 
-    public function testAvailableOnlyReturnsUnassignedUnoccupiedUnreservedStands()
+    public function testAvailableOnlyReturnsUnassignedUnoccupiedUnreservedOpenStands()
     {
         $extraStand = Stand::find(1)->replicate();
         $extraStand->identifier = 'NEW';
@@ -50,6 +50,11 @@ class StandTest extends BaseFunctionalTestCase
 
         NetworkAircraft::find('BAW123')->occupiedStand()->sync([1]);
         StandAssignment::create(['callsign' => 'BAW123', 'stand_id' => 2]);
+
+        $closedStand = Stand::find(1)->replicate();
+        $closedStand->identifier = 'CLOSED';
+        $closedStand->closed_at = Carbon::now();
+        $closedStand->save();
 
         $stands = Stand::available()->get()->pluck('id')->toArray();
         $this->assertEquals([3], $stands);

--- a/tests/app/Services/StandServiceTest.php
+++ b/tests/app/Services/StandServiceTest.php
@@ -1232,8 +1232,6 @@ class StandServiceTest extends BaseFunctionalTestCase
                     'identifier' => 'TEST10',
                     'type' => null,
                     'status' => 'closed',
-                    'callsign' => null,
-                    'reserved_at' => null,
                     'airlines' => [],
                     'max_wake_category' => 'LM',
                     'max_aircraft_type' => null,

--- a/tests/app/Services/StandServiceTest.php
+++ b/tests/app/Services/StandServiceTest.php
@@ -1136,6 +1136,17 @@ class StandServiceTest extends BaseFunctionalTestCase
             ]
         );
 
+        // Stand 10 is closed
+        $stand10 = Stand::create(
+            [
+                'airfield_id' => 1,
+                'identifier' => 'TEST10',
+                'latitude' => 54.658828,
+                'longitude' =>  -6.222070,
+            ]
+        );
+        $stand10->close();
+
         $this->assertEquals(
             [
                 [
@@ -1213,6 +1224,16 @@ class StandServiceTest extends BaseFunctionalTestCase
                     'status' => 'reserved_soon',
                     'callsign' => null,
                     'reserved_at' => Carbon::now()->addMinutes(59)->startOfSecond(),
+                    'airlines' => [],
+                    'max_wake_category' => 'LM',
+                    'max_aircraft_type' => null,
+                ],
+                [
+                    'identifier' => 'TEST10',
+                    'type' => null,
+                    'status' => 'closed',
+                    'callsign' => null,
+                    'reserved_at' => null,
                     'airlines' => [],
                     'max_wake_category' => 'LM',
                     'max_aircraft_type' => null,


### PR DESCRIPTION
Airfields do renovation work, stands get closed and we choose to replicate this on the SMRs. Therefore the automatic stand allocator should not allow stands that are closed to be allocated.