### PR TITLE
build(actions): Auto merge minor dependabot revisions

### DIFF
--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -1,0 +1,39 @@
+name: Dependabot Merge
+
+on:
+  repository_dispatch:
+    types: [dependabot-auto-merge-trigger]
+
+jobs:
+  approve-and-merge:
+    name: Approve and Merge
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ukcp-api-dependabot-auto-merge
+      cancel-in-progress: true
+    steps:
+      - name: Get dependabot metadata
+        id: dependabot
+        uses: dependabot/fetch-metadata@v1.1.1
+        with:
+          github-token: "${{ secrets.PAT }}"
+
+      - name: Check merge conditions
+        id: merge-conditions-check
+        if: contains('version-update:semver-patch,version-update:semver-minor', steps.dependabot.outputs.update-type) &&
+          contains('direct:production,indirect:production', steps.dependabot.outputs.dependency-type)
+        run: echo "Auto merge conditions satisfied"
+
+      - name: Approve dependabot pull request
+        if:  ${{ steps.merge-conditions-check.conclusion == 'success' }}
+        env:
+          PR_URL: ${{ github.event.client_payload.pull_request_url }}
+          GITHUB_TOKEN: ${{secrets.PAT}}
+        run: gh pr review --approve "$PR_URL"
+
+      - name: Merge dependabot pull request
+        if: ${{ steps.merge-conditions-check.conclusion == 'success' }}
+        env:
+          PR_URL: ${{ github.event.client_payload.pull_request_url }}
+          GITHUB_TOKEN: ${{secrets.PAT}}
+        run: gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -1,39 +1,34 @@
 name: Dependabot Merge
 
 on:
-  repository_dispatch:
-    types: [dependabot-auto-merge-trigger]
+  workflow_run:
+    workflows: [ "Tests" ]
+    types: [ "completed" ]
 
 jobs:
   approve-and-merge:
     name: Approve and Merge
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.event == 'pull_request'}} &&
+      ${{ github.event.workflow_run.conclusion == 'success' }}
     concurrency:
       group: ukcp-api-dependabot-auto-merge
       cancel-in-progress: true
     steps:
-      - name: Get dependabot metadata
-        id: dependabot
-        uses: dependabot/fetch-metadata@v1.1.1
+      - name: Download Pull Request Number
+        uses: actions/download-artifact@v2
         with:
-          github-token: "${{ secrets.PAT }}"
+          name: pr-number
+          path: ~/pr-number
 
-      - name: Check merge conditions
-        id: merge-conditions-check
-        if: contains('version-update:semver-patch,version-update:semver-minor', steps.dependabot.outputs.update-type) &&
-          contains('direct:production,indirect:production', steps.dependabot.outputs.dependency-type)
-        run: echo "Auto merge conditions satisfied"
+      - name: Set Pull Request Number
+        run: |
+          NUM=$(cat ~/pr-number)
+          echo "PR_NUMBER=$NUM" >> $GITHUB_ENV
 
-      - name: Approve dependabot pull request
-        if:  ${{ steps.merge-conditions-check.conclusion == 'success' }}
-        env:
-          PR_URL: ${{ github.event.client_payload.pull_request_url }}
-          GITHUB_TOKEN: ${{secrets.PAT}}
-        run: gh pr review --approve "$PR_URL"
-
-      - name: Merge dependabot pull request
-        if: ${{ steps.merge-conditions-check.conclusion == 'success' }}
-        env:
-          PR_URL: ${{ github.event.client_payload.pull_request_url }}
-          GITHUB_TOKEN: ${{secrets.PAT}}
-        run: gh pr merge --auto --squash "$PR_URL"
+      - name: Merge Dependabot
+        uses: fastify/github-action-merge-dependabot@v3.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          target: minor
+          pr-number: ${{ env.PR_NUMBER }}

--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -13,7 +13,6 @@ jobs:
       ${{ github.event.workflow_run.conclusion == 'success' }}
     concurrency:
       group: ukcp-api-dependabot-auto-merge
-      cancel-in-progress: true
     steps:
       - name: Download Pull Request Number
         uses: actions/download-artifact@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -191,6 +191,7 @@ jobs:
   pr-number:
     name: Pull Request Number
     needs: test
+    if: ${{ github.event.workflow_run.event == 'pull_request'}}
     runs-on: ubuntu-latest
     steps:
       - name: Save pull request number

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -188,3 +188,16 @@ jobs:
         with:
           token: ${{ secrets.PAT }}
           event-type: release-trigger
+
+  merge-dependabot:
+    name: Dependabot Auto Merge
+    needs: test
+    if: github.event_name == 'pull_request' && github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger auto merge workflow
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.PAT }}
+          event-type: dependabot-auto-merge-trigger
+          client-payload: '{"pull_request_url": "${{github.event.pull_request.html_url}}"}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,9 +20,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4']
-        composer: ['v2']
-        experimental: [false]
+        php: [ '7.4' ]
+        composer: [ 'v2' ]
+        experimental: [ false ]
     services:
       mysql:
         image: mysql:8.0
@@ -171,7 +171,7 @@ jobs:
       - name: Upload Code Coverage Report
         if: matrix.php == '7.4'
         uses: codecov/codecov-action@v2
-        with: 
+        with:
           fail_ci_if_error: true
 
   trigger-release:
@@ -189,15 +189,16 @@ jobs:
           token: ${{ secrets.PAT }}
           event-type: release-trigger
 
-  merge-dependabot:
-    name: Dependabot Auto Merge
+  pr-number:
+    name: Pull Request Number
     needs: test
-    if: github.event_name == 'pull_request' && github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger auto merge workflow
-        uses: peter-evans/repository-dispatch@v1
+      - name: Save pull request number
+        run: echo ${{ github.event.number }} > ~/pr-number
+
+      - name: Upload pull request number artifact
+        uses: actions/upload-artifact@v2
         with:
-          token: ${{ secrets.PAT }}
-          event-type: dependabot-auto-merge-trigger
-          client-payload: '{"pull_request_url": "${{github.event.pull_request.html_url}}"}'
+          name: pr-number
+          path: ~/pr-number


### PR DESCRIPTION
Save me the effort of merging dependabot every week... auto merge anything that is a minor or patch version from dependabot as soon as it passes CI.