### PR TITLE
fix(metars): broadcast metar data in the correct format

### DIFF
--- a/app/Events/MetarsUpdatedEvent.php
+++ b/app/Events/MetarsUpdatedEvent.php
@@ -22,20 +22,23 @@ class MetarsUpdatedEvent extends HighPriorityBroadcastEvent
 
     public function broadcastWith(): array
     {
-        return $this->metars->map(function (Metar $metar) {
-            return [
-                'airfield_id' => $metar->airfield_id,
-                'raw' => $metar->raw,
-                'parsed' => $metar->parsed,
+        return
+            [
+                'metars' => $this->metars->map(function (Metar $metar) {
+                    return [
+                        'airfield_id' => $metar->airfield_id,
+                        'raw' => $metar->raw,
+                        'parsed' => $metar->parsed,
+                    ];
+                })->toArray()
             ];
-        })->toArray();
     }
 
     public function broadcastOn()
     {
         return [new PrivateChannel('metar_updates')];
     }
-    
+
     public function broadcastAs()
     {
         return "metars.updated";

--- a/tests/app/Events/MetarsUpdatedEventTest.php
+++ b/tests/app/Events/MetarsUpdatedEventTest.php
@@ -26,7 +26,7 @@ class MetarsUpdatedEventTest extends BaseFunctionalTestCase
     {
         $this->assertEquals([new PrivateChannel('metar_updates')], $this->event->broadcastOn());
     }
-    
+
     public function testItBroadcastsAsEvent()
     {
         $this->assertEquals("metars.updated", $this->event->broadcastAs());
@@ -35,15 +35,17 @@ class MetarsUpdatedEventTest extends BaseFunctionalTestCase
     public function testItBroadcastsMetarData()
     {
         $expected = [
-            [
-                'airfield_id' => $this->metar1->airfield_id,
-                'raw' => $this->metar1->raw,
-                'parsed' => $this->metar1->parsed,
-            ],
-            [
-                'airfield_id' => $this->metar2->airfield_id,
-                'raw' => $this->metar2->raw,
-                'parsed' => $this->metar2->parsed,
+            'metars' => [
+                [
+                    'airfield_id' => $this->metar1->airfield_id,
+                    'raw' => $this->metar1->raw,
+                    'parsed' => $this->metar1->parsed,
+                ],
+                [
+                    'airfield_id' => $this->metar2->airfield_id,
+                    'raw' => $this->metar2->raw,
+                    'parsed' => $this->metar2->parsed,
+                ],
             ],
         ];
 


### PR DESCRIPTION
The plugin expects push events to be an object, with underlying data. The MetarsUpdatedEvent was
returning a JSON array. This change makes it return an object instead.

fix #774