### PR TITLE
fix(metars): Fix metar caching

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -95,7 +95,7 @@ class Kernel extends ConsoleKernel
             ->cron('0 1-7 * * *');
         $schedule->command('horizon:snapshot')->everyFiveMinutes();
         $schedule->command('plugin-events:clean')->everyTenMinutes();
-        $schedule->command('metars:update')->everyFiveMinutes();
+        $schedule->command('metars:update')->everyMinute();
         $schedule->command('database:check-table-updates')->everyMinute();
     }
 }

--- a/app/Services/Metar/MetarRetrievalService.php
+++ b/app/Services/Metar/MetarRetrievalService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services\Metar;
 
+use Carbon\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
@@ -36,6 +37,6 @@ class MetarRetrievalService
 
     private function getMetarQueryString(Collection $airfields): string
     {
-        return $airfields->implode(',');
+        return $airfields->concat([Carbon::now()->timestamp])->implode(',');
     }
 }

--- a/tests/app/Services/Metar/MetarServiceTest.php
+++ b/tests/app/Services/Metar/MetarServiceTest.php
@@ -12,6 +12,7 @@ use App\Services\Metar\Parser\PressureParser;
 use App\Services\Metar\Parser\VisibilityParser;
 use App\Services\Metar\Parser\WindParser;
 use App\Services\Metar\Parser\WindVariationParser;
+use Carbon\Carbon;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
@@ -29,6 +30,7 @@ class MetarServiceTest extends BaseFunctionalTestCase
         parent::setUp();
         $this->service = $this->app->make(MetarService::class);
         Event::fake();
+        Carbon::setTestNow(Carbon::now());
     }
 
     public function testItParsesMetars()
@@ -47,7 +49,12 @@ class MetarServiceTest extends BaseFunctionalTestCase
 
 
         $expectedUrl = config(self::URL_CONFIG_KEY) . '?id=' . urlencode(
-                sprintf('EGLL,EGBB,EGKR,%s,%s', $noPressureAirfield->code, $noMetarAirfield->code)
+                sprintf(
+                    'EGLL,EGBB,EGKR,%s,%s,%s',
+                    $noPressureAirfield->code,
+                    $noMetarAirfield->code,
+                    Carbon::now()->timestamp
+                )
             );
         Http::fake(
             [
@@ -61,7 +68,12 @@ class MetarServiceTest extends BaseFunctionalTestCase
         Http::assertSent(function (Request $request) use ($noPressureAirfield, $noMetarAirfield) {
             return $request->method() === 'GET' &&
                 Str::startsWith($request->url(), config(self::URL_CONFIG_KEY)) &&
-                $request['id'] === sprintf('EGLL,EGBB,EGKR,%s,%s', $noPressureAirfield->code, $noMetarAirfield->code);
+                $request['id'] === sprintf(
+                    'EGLL,EGBB,EGKR,%s,%s,%s',
+                    $noPressureAirfield->code,
+                    $noMetarAirfield->code,
+                    Carbon::now()->timestamp
+                );
         });
 
         // Check the metars are in the database
@@ -114,7 +126,9 @@ class MetarServiceTest extends BaseFunctionalTestCase
         $this->doesntExpectEvents(MetarsUpdatedEvent::class);
         Http::fake(
             [
-                config(self::URL_CONFIG_KEY) . '?id=' . urlencode('EGLL,EGBB,EGKR') => Http::response('', 500),
+                config(self::URL_CONFIG_KEY) . '?id=' . urlencode(
+                    'EGLL,EGBB,EGKR,' . Carbon::now()->timestamp
+                ) => Http::response('', 500),
             ]
         );
 
@@ -124,7 +138,7 @@ class MetarServiceTest extends BaseFunctionalTestCase
         Http::assertSent(function (Request $request) {
             return $request->method() === 'GET' &&
                 Str::startsWith($request->url(), config(self::URL_CONFIG_KEY)) &&
-                $request['id'] === 'EGLL,EGBB,EGKR';
+                $request['id'] === 'EGLL,EGBB,EGKR,' . Carbon::now()->timestamp;
         });
 
         $this->assertDatabaseCount(
@@ -162,7 +176,12 @@ class MetarServiceTest extends BaseFunctionalTestCase
         ];
 
         $expectedUrl = config(self::URL_CONFIG_KEY) . '?id=' . urlencode(
-                sprintf('EGLL,EGBB,EGKR,%s,%s', $metarOne->airfield->code, $metarTwo->airfield->code)
+                sprintf(
+                    'EGLL,EGBB,EGKR,%s,%s,%s',
+                    $metarOne->airfield->code,
+                    $metarTwo->airfield->code,
+                    Carbon::now()->timestamp
+                )
             );
         Http::fake(
             [
@@ -177,9 +196,10 @@ class MetarServiceTest extends BaseFunctionalTestCase
             return $request->method() === 'GET' &&
                 Str::startsWith($request->url(), config(self::URL_CONFIG_KEY)) &&
                 $request['id'] === sprintf(
-                    'EGLL,EGBB,EGKR,%s,%s',
+                    'EGLL,EGBB,EGKR,%s,%s,%s',
                     $metarOne->airfield->code,
-                    $metarTwo->airfield->code
+                    $metarTwo->airfield->code,
+                    Carbon::now()->timestamp
                 );
         });
 
@@ -200,7 +220,12 @@ class MetarServiceTest extends BaseFunctionalTestCase
         ];
 
         $expectedUrl = config(self::URL_CONFIG_KEY) . '?id=' . urlencode(
-                sprintf('EGLL,EGBB,EGKR,%s,%s', $metarOne->airfield->code, $metarTwo->airfield->code)
+                sprintf(
+                    'EGLL,EGBB,EGKR,%s,%s,%s',
+                    $metarOne->airfield->code,
+                    $metarTwo->airfield->code,
+                    Carbon::now()->timestamp
+                )
             );
         Http::fake(
             [
@@ -215,9 +240,10 @@ class MetarServiceTest extends BaseFunctionalTestCase
             return $request->method() === 'GET' &&
                 Str::startsWith($request->url(), config(self::URL_CONFIG_KEY)) &&
                 $request['id'] === sprintf(
-                    'EGLL,EGBB,EGKR,%s,%s',
+                    'EGLL,EGBB,EGKR,%s,%s,%s',
                     $metarOne->airfield->code,
-                    $metarTwo->airfield->code
+                    $metarTwo->airfield->code,
+                    Carbon::now()->timestamp
                 );
         });
 


### PR DESCRIPTION
Metars get cached by .net so we need to make the request a little different each time.

Fixes #790