### PR TITLE
data(stands): EGNX cargo stand priority

### DIFF
--- a/database/migrations/2022_01_20_194507_east_midlands_cargo_priority.php
+++ b/database/migrations/2022_01_20_194507_east_midlands_cargo_priority.php
@@ -1,0 +1,60 @@
+<?php
+
+use Carbon\Carbon;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+class EastMidlandsCargoPriority extends Migration
+{
+    const STANDS = [
+        '70',
+        '70L',
+        '70R',
+        '71',
+        '72',
+        '73',
+        '73L',
+        '74',
+        '74L',
+        '75',
+        '75R',
+        '76',
+        '76L',
+        '76R',
+        '77',
+        '77L',
+        '77R',
+        '78',
+        '78L',
+        '78R',
+        '78X',
+        '79',
+        '80',
+    ];
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::table('stands')
+            ->where('airfield_id', DB::table('airfield')->where('code', 'EGNX')->first()->id)
+            ->whereIn('identifier', self::STANDS)
+            ->update(['assignment_priority' => 2, 'updated_at' => Carbon::now()]);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        DB::table('stands')
+            ->where('airfield_id', DB::table('airfield')->where('code', 'EGNX')->first()->id)
+            ->whereIn('identifier', self::STANDS)
+            ->update(['assignment_priority' => 1, 'updated_at' => Carbon::now()]);
+    }
+}


### PR DESCRIPTION
East midland Cargo default is to prefer West apron if no specific stand requirements, so make the West apron just that little bit more appealing to the allocator than the east.