### PR TITLE
data(controllers): Update controller positions to properly reflect 25khz spacing

### DIFF
--- a/database/migrations/2022_02_07_191417_controller_frequency_conversions.php
+++ b/database/migrations/2022_02_07_191417_controller_frequency_conversions.php
@@ -1,0 +1,46 @@
+<?php
+
+use App\Models\Controller\ControllerPosition;
+use Illuminate\Database\Migrations\Migration;
+
+class ControllerFrequencyConversions extends Migration
+{
+    const TO_UPDATE_PATTERN = '/^(\d{3})\.(\d)([27])$/';
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $toUpdate = [];
+        foreach (ControllerPosition::all() as $position) {
+            $matches = [];
+            if (preg_match(self::TO_UPDATE_PATTERN, (string)$position->frequency, $matches) !== 1) {
+                continue;
+            }
+
+            $toUpdate[] = [
+                'callsign' => $position->callsign,
+                'frequency' => sprintf('%s.%s%s5', $matches[1], $matches[2], $matches[3]),
+            ];
+        }
+
+        ControllerPosition::upsert(
+            $toUpdate,
+            ['callsign'],
+            ['frequency']
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}


### PR DESCRIPTION
This is now possible with velocity. Should be deployed either on the 23rd or
very early on the 24th for airac day. This includes both enroute and aerodrome
positions as it makes sense to do them all at once.

Resolve #828
Resolve #817