### PR TITLE
feat: Add endpoints for administering controller notifications

### DIFF
--- a/app/Http/Controllers/Admin/AllPositionsController.php
+++ b/app/Http/Controllers/Admin/AllPositionsController.php
@@ -7,13 +7,13 @@ use App\Models\Controller\ControllerPosition;
 
 class AllPositionsController extends BaseController
 {
-	public function __invoke()
-	{
-		// define fields which are superfluous for the purpose of this endpoint.
+    public function __invoke()
+    {
+        // define fields which are superfluous for the purpose of this endpoint.
         $irrelevantFields = ['requests_departure_releases', 'receives_departure_releases', 'sends_prenotes', 'receives_prenotes'];
-			  
+              
         $positions = ControllerPosition::all()->makeHidden($irrelevantFields)->toArray();
 
         return response()->json(['positions' => $positions]);
-	}
+    }
 }

--- a/app/Http/Controllers/Admin/AllPositionsController.php
+++ b/app/Http/Controllers/Admin/AllPositionsController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\BaseController;
+use App\Models\Controller\ControllerPosition;
+
+class AllPositionsController extends BaseController
+{
+	public function __invoke()
+	{
+		// define fields which are superfluous for the purpose of this endpoint.
+        $irrelevantFields = ['requests_departure_releases', 'receives_departure_releases', 'sends_prenotes', 'receives_prenotes'];
+			  
+        $positions = ControllerPosition::all()->makeHidden($irrelevantFields)->toArray();
+
+        return response()->json(['positions' => $positions]);
+	}
+}

--- a/app/Http/Controllers/Admin/NotificationAdminController.php
+++ b/app/Http/Controllers/Admin/NotificationAdminController.php
@@ -12,103 +12,103 @@ use Illuminate\Http\Request;
 
 class NotificationAdminController extends BaseController
 {
-	/**
-	 * Get a list of all notifications, optionally including expired
-	 * notifications via query parameter in request.
-	 *
-	 * @param Request $request
-	 * @return JsonResponse
-	 */
-	public function getNotifications(Request $request) : JsonResponse
-	{
-		// if the requester wishes to view expired notifications
-		// include expired in the query results
-		if ($request->query('include_expired', false)) {
+    /**
+     * Get a list of all notifications, optionally including expired
+     * notifications via query parameter in request.
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function getNotifications(Request $request) : JsonResponse
+    {
+        // if the requester wishes to view expired notifications
+        // include expired in the query results
+        if ($request->query('include_expired', false)) {
             $notifications = Notification::withCount('controllers')->get();
-		} else {
+        } else {
             $notifications = Notification::active()->withCount('controllers')->get();
-		}
+        }
 
         return response()->json(['notifications' => $notifications]);
-	}
+    }
 
-	/**
-	 * Retrieve the details on a specified notification, appending
-	 * relevant details for further consumption
-	 *
-	 * @param Notification $notification
-	 * @return JsonResponse
-	 */
-	public function getNotification(Notification $notification) : JsonResponse
-	{
-		// eager load controllers relationship
+    /**
+     * Retrieve the details on a specified notification, appending
+     * relevant details for further consumption
+     *
+     * @param Notification $notification
+     * @return JsonResponse
+     */
+    public function getNotification(Notification $notification) : JsonResponse
+    {
+        // eager load controllers relationship
         $notification->load('controllers');
-		// include boolean as to if the notification is still active for QoL.
+        // include boolean as to if the notification is still active for QoL.
         $notification->setAppends(['active']);
 
-		// to avoid breaking changes, add new key separate to the
-		// toArray functionality to add detailed list of controller_positions
-		// to allow them to be updated.
+        // to avoid breaking changes, add new key separate to the
+        // toArray functionality to add detailed list of controller_positions
+        // to allow them to be updated.
         $notification['positions'] = $notification->controllers;
-		// only convert attributes to an array, not default relationship conversion defined in toArray.
+        // only convert attributes to an array, not default relationship conversion defined in toArray.
         return response()->json(['notification' => $notification->attributesToArray()]);
-	}
+    }
 
-	/**
-	 * Based upon a valid request, create a new notification and assign it positions.
-	 *
-	 * @param NotificationRequest $request
-	 * @return JsonResponse
-	 */
-	public function createNotification(NotificationRequest $request) : JsonResponse
-	{
-		// if all_positions is specified, any data at the positions key will be excluded
-		// so conditionally select the right data.
+    /**
+     * Based upon a valid request, create a new notification and assign it positions.
+     *
+     * @param NotificationRequest $request
+     * @return JsonResponse
+     */
+    public function createNotification(NotificationRequest $request) : JsonResponse
+    {
+        // if all_positions is specified, any data at the positions key will be excluded
+        // so conditionally select the right data.
         $positions = $request->get('all_positions', false) ? ControllerPosition::all() : collect($request->get('positions'));
 
-		// only need to check the positions validity when they have been specified.
-		if (!$request->get('all_positions', false)) {
-			$validPositions = ControllerPosition::all()->pluck('id');
+        // only need to check the positions validity when they have been specified.
+        if (!$request->get('all_positions', false)) {
+            $validPositions = ControllerPosition::all()->pluck('id');
 
-			$positionsAreValid = $positions->every(function($position) use ($validPositions) {
-				return $validPositions->contains($position);
-			});
+            $positionsAreValid = $positions->every(function ($position) use ($validPositions) {
+                return $validPositions->contains($position);
+            });
 
-			if (!$positionsAreValid) {
-				return response()->json(['message' => 'Invalid positions.'], 400);
-			}
+            if (!$positionsAreValid) {
+                return response()->json(['message' => 'Invalid positions.'], 400);
+            }
 
-			// once valid, replace with a collection of models instead of a
-			// collection of IDs so it can be used to create a valid relationship.
+            // once valid, replace with a collection of models instead of a
+            // collection of IDs so it can be used to create a valid relationship.
             $positions = ControllerPosition::findMany($positions);
-		}
+        }
 
-		$notification = Notification::create([
-			'title' => $request->get('title'),
-			'body' => $request->get('body'),
-			'link' => $request->get('link'),
-			'valid_from' => Carbon::parse($request->get('valid_from')),
-			'valid_to' => Carbon::parse($request->get('valid_to'))
-		]);
+        $notification = Notification::create([
+            'title' => $request->get('title'),
+            'body' => $request->get('body'),
+            'link' => $request->get('link'),
+            'valid_from' => Carbon::parse($request->get('valid_from')),
+            'valid_to' => Carbon::parse($request->get('valid_to'))
+        ]);
 
-		// associate with the relevant positions
+        // associate with the relevant positions
         $notification->controllers()->saveMany($positions);
 
         return response()->json(['notification_id' => $notification->id], 201);
-	}
+    }
 
-	/**
-	 * Delete (via soft-delete) a notification.
-	 *
-	 * @param Notification $notification
-	 * @return JsonResponse
-	 */
-	public function deleteNotification(Notification $notification) : JsonResponse
-	{
-		// this delete operation will SoftDelete the model, and preserve
-		// relationships.
+    /**
+     * Delete (via soft-delete) a notification.
+     *
+     * @param Notification $notification
+     * @return JsonResponse
+     */
+    public function deleteNotification(Notification $notification) : JsonResponse
+    {
+        // this delete operation will SoftDelete the model, and preserve
+        // relationships.
         $notification->delete();
 
         return response()->json([], 204);
-	}
+    }
 }

--- a/app/Http/Controllers/Admin/NotificationAdminController.php
+++ b/app/Http/Controllers/Admin/NotificationAdminController.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\BaseController;
+use App\Http\Requests\NotificationRequest;
+use App\Models\Controller\ControllerPosition;
+use App\Models\Notification\Notification;
+use Carbon\Carbon;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class NotificationAdminController extends BaseController
+{
+	/**
+	 * Get a list of all notifications, optionally including expired
+	 * notifications via query parameter in request.
+	 *
+	 * @param Request $request
+	 * @return JsonResponse
+	 */
+	public function getNotifications(Request $request) : JsonResponse
+	{
+		// if the requester wishes to view expired notifications
+		// include expired in the query results
+		if ($request->query('include_expired', false)) {
+            $notifications = Notification::withCount('controllers')->get();
+		} else {
+            $notifications = Notification::active()->withCount('controllers')->get();
+		}
+
+        return response()->json(['notifications' => $notifications]);
+	}
+
+	/**
+	 * Retrieve the details on a specified notification, appending
+	 * relevant details for further consumption
+	 *
+	 * @param Notification $notification
+	 * @return JsonResponse
+	 */
+	public function getNotification(Notification $notification) : JsonResponse
+	{
+		// eager load controllers relationship
+        $notification->load('controllers');
+		// include boolean as to if the notification is still active for QoL.
+        $notification->setAppends(['active']);
+
+		// to avoid breaking changes, add new key separate to the
+		// toArray functionality to add detailed list of controller_positions
+		// to allow them to be updated.
+        $notification['positions'] = $notification->controllers;
+		// only convert attributes to an array, not default relationship conversion defined in toArray.
+        return response()->json(['notification' => $notification->attributesToArray()]);
+	}
+
+	/**
+	 * Based upon a valid request, create a new notification and assign it positions.
+	 *
+	 * @param NotificationRequest $request
+	 * @return JsonResponse
+	 */
+	public function createNotification(NotificationRequest $request) : JsonResponse
+	{
+		// if all_positions is specified, any data at the positions key will be excluded
+		// so conditionally select the right data.
+        $positions = $request->get('all_positions', false) ? ControllerPosition::all() : collect($request->get('positions'));
+
+		// only need to check the positions validity when they have been specified.
+		if (!$request->get('all_positions', false)) {
+			$validPositions = ControllerPosition::all()->pluck('id');
+
+			$positionsAreValid = $positions->every(function($position) use ($validPositions) {
+				return $validPositions->contains($position);
+			});
+
+			if (!$positionsAreValid) {
+				return response()->json(['message' => 'Invalid positions.'], 400);
+			}
+
+			// once valid, replace with a collection of models instead of a
+			// collection of IDs so it can be used to create a valid relationship.
+            $positions = ControllerPosition::findMany($positions);
+		}
+
+		$notification = Notification::create([
+			'title' => $request->get('title'),
+			'body' => $request->get('body'),
+			'link' => $request->get('link'),
+			'valid_from' => Carbon::parse($request->get('valid_from')),
+			'valid_to' => Carbon::parse($request->get('valid_to'))
+		]);
+
+		// associate with the relevant positions
+        $notification->controllers()->saveMany($positions);
+
+        return response()->json(['notification_id' => $notification->id], 201);
+	}
+
+	/**
+	 * Delete (via soft-delete) a notification.
+	 *
+	 * @param Notification $notification
+	 * @return JsonResponse
+	 */
+	public function deleteNotification(Notification $notification) : JsonResponse
+	{
+		// this delete operation will SoftDelete the model, and preserve
+		// relationships.
+        $notification->delete();
+
+        return response()->json([], 204);
+	}
+}

--- a/app/Http/Requests/NotificationRequest.php
+++ b/app/Http/Requests/NotificationRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class NotificationRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'title' => 'required|string',
+            'link' => 'required|active_url',
+            'body' => 'required|string',
+            'valid_from' => 'required|date|before:valid_to',
+            'valid_to' => 'required|date|after:valid_from',
+            'all_positions' => 'boolean',
+            'positions' => 'required_if:all_positions,false|exclude_if:all_positions,true|array'
+        ];
+    }
+}

--- a/app/Http/Requests/NotificationRequest.php
+++ b/app/Http/Requests/NotificationRequest.php
@@ -25,7 +25,7 @@ class NotificationRequest extends FormRequest
     {
         return [
             'title' => 'required|string',
-            'link' => 'required|active_url',
+            'link' => 'required|url',
             'body' => 'required|string',
             'valid_from' => 'required|date|before:valid_to',
             'valid_to' => 'required|date|after:valid_from',

--- a/app/Models/Notification/Notification.php
+++ b/app/Models/Notification/Notification.php
@@ -5,13 +5,14 @@ namespace App\Models\Notification;
 use App\Models\Controller\ControllerPosition;
 use App\Models\User\User;
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Notification extends Model
 {
-    use SoftDeletes;
+    use SoftDeletes, HasFactory;
 
     protected $fillable = [
         'title',
@@ -63,5 +64,10 @@ class Notification extends Model
             'notification_id',
             'user_id'
         );
+    }
+
+    public function getActiveAttribute() : bool
+    {
+        return $this->valid_to >= Carbon::now();
     }
 }

--- a/database/factories/Notification/NotificationFactory.php
+++ b/database/factories/Notification/NotificationFactory.php
@@ -27,8 +27,8 @@ class NotificationFactory extends Factory
 
     public function expired()
     {
-        return $this->state(fn() => [
-            'valid_from' => Carbon::now()->subHours(3), 
+        return $this->state(fn () => [
+            'valid_from' => Carbon::now()->subHours(3),
             'valid_to' => Carbon::now()->subHour()
         ]);
     }

--- a/database/factories/Notification/NotificationFactory.php
+++ b/database/factories/Notification/NotificationFactory.php
@@ -27,9 +27,11 @@ class NotificationFactory extends Factory
 
     public function expired()
     {
-        return $this->state(fn () => [
-            'valid_from' => Carbon::now()->subHours(3),
-            'valid_to' => Carbon::now()->subHour()
-        ]);
+        return $this->state(function () {
+            return [
+                'valid_from' => Carbon::now()->subHours(3),
+                'valid_to' => Carbon::now()->subHour()
+            ];
+        });
     }
 }

--- a/database/factories/Notification/NotificationFactory.php
+++ b/database/factories/Notification/NotificationFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Database\Factories\Notification;
+
+use App\Models\Notification\Notification;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class NotificationFactory extends Factory
+{
+    protected $model = Notification::class;
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'title' => $this->faker->sentence(),
+            'body' => $this->faker->sentences(3, true),
+            'link' => $this->faker->url(),
+            'valid_from' => Carbon::now(),
+            'valid_to' => Carbon::now()->addHours(2),
+        ];
+    }
+
+    public function expired()
+    {
+        return $this->state(fn() => [
+            'valid_from' => Carbon::now()->subHours(3), 
+            'valid_to' => Carbon::now()->subHour()
+        ]);
+    }
+}

--- a/docs/admin/admin-functions.yml
+++ b/docs/admin/admin-functions.yml
@@ -205,6 +205,58 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/HoldModel'
+    ControllerPosition:
+      properties:
+        id:
+          type: integer
+        callsign:
+          type: string
+          example: "EGLL_S_TWR"
+        frequency:
+          type: number
+    NotificationModel:
+      properties:
+        title:
+          type: string
+          example: Procedure Change A
+        body:
+          type: string
+          description: Content of notification message
+        link:
+          type: string
+          description: Link to main notification
+        valid_from:
+          type: string
+          format: date-time
+        valid_to:
+          type: string
+          format: date-time
+    NotificationRequest:
+      allOf:
+      - $ref: '#/components/schemas/NotificationModel'
+      - type: object
+        properties:
+          all_positions:
+            type: boolean
+            description: If true, notifications will be created against every position
+          positions:
+            type: array
+            items:
+              type: integer
+            description: List of position IDs to create the notification for. Is ignored if all_properties true
+    NotificationDetail:
+      allOf:
+      - $ref: '#/components/schemas/NotificationModel'
+      - type: object
+        properties:
+          active:
+            type: boolean
+          positions:
+            type: array
+            items:
+              $ref: '#/components/schemas/ControllerPosition'
+
+
 
   responses:
     AirfieldNotFound:
@@ -629,3 +681,93 @@ paths:
           $ref: '#/components/responses/ConflictOnHoldDescription'
         '204':
           description: No content
+
+  /notifications:
+    get:
+      tags:
+      - 'notifications'
+      parameters:
+        - in: query
+          name: 'include_expired'
+          required: false
+          schema:
+            type: boolean
+            default: false
+          description: Request to include expired notifications in response.
+      responses:
+        '200':
+          description: 'Success'
+          content:
+            'application/json':
+              schema:
+                properties:
+                  notifications:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/NotificationModel'
+    post:
+      tags:
+        - 'notifications'
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/NotificationRequest'
+      responses:
+        '201':
+          description: Created
+          content:
+            'application/json':
+              schema:
+                properties:
+                  notification_id:
+                    type: integer
+        '422':
+          description: Validation errors
+        '400':
+          description: Invalid positions
+
+  /notifications/{notification_id}:
+    get:
+      tags:
+      - 'notifications'
+      parameters:
+        - in: path
+          name: notification_id
+          schema:
+            type: integer
+          required: true
+      responses:
+        '200':
+          description: Successful
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/NotificationDetail'
+        '404':
+          description: Not found
+    delete:
+      tags:
+      - 'notifications'
+      parameters:
+        - in: path
+          name: notification_id
+          schema:
+            type: integer
+          required: true
+      responses:
+        '204':
+          description: Successful
+        '404':
+          description: Not found
+
+  /controller-positions:
+    get:
+      responses:
+        '200':
+          description: Success
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ControllerPosition'
+            

--- a/docs/admin/admin-functions.yml
+++ b/docs/admin/admin-functions.yml
@@ -770,4 +770,3 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/ControllerPosition'
-            

--- a/routes/api.php
+++ b/routes/api.php
@@ -252,10 +252,13 @@ Route::middleware('api')->group(
                         Route::get('/stand-types', 'Admin\\StandAdminController@getTypes');
 
                         Route::get('/controller-positions', 'Admin\\AllPositionsController');
-                        Route::get('/notifications', 'Admin\\NotificationAdminController@getNotifications');
-                        Route::post('/notifications', 'Admin\\NotificationAdminController@createNotification');
-                        Route::get('/notifications/{notification}', 'Admin\\NotificationAdminController@getNotification');
-                        Route::delete('/notifications/{notification}', 'Admin\\NotificationAdminController@deleteNotification');
+
+                        Route::prefix('/notifications')->group(function () {
+                            Route::get('', 'Admin\\NotificationAdminController@getNotifications');
+                            Route::post('', 'Admin\\NotificationAdminController@createNotification');
+                            Route::get('/{notification}', 'Admin\\NotificationAdminController@getNotification');
+                            Route::delete('/{notification}', 'Admin\\NotificationAdminController@deleteNotification');
+                        });
                     }
                 );
             }

--- a/routes/api.php
+++ b/routes/api.php
@@ -250,6 +250,12 @@ Route::middleware('api')->group(
                         Route::post('/navaids', 'Admin\\NavaidAdminController@createNavaid');
 
                         Route::get('/stand-types', 'Admin\\StandAdminController@getTypes');
+
+                        Route::get('/controller-positions', 'Admin\\AllPositionsController');
+                        Route::get('/notifications', 'Admin\\NotificationAdminController@getNotifications');
+                        Route::post('/notifications', 'Admin\\NotificationAdminController@createNotification');
+                        Route::get('/notifications/{notification}', 'Admin\\NotificationAdminController@getNotification');
+                        Route::delete('/notifications/{notification}', 'Admin\\NotificationAdminController@deleteNotification');
                     }
                 );
             }

--- a/tests/app/Http/Controllers/Admin/NotificationAdminControllerTest.php
+++ b/tests/app/Http/Controllers/Admin/NotificationAdminControllerTest.php
@@ -24,7 +24,7 @@ class NotificationAdminControllerTest extends BaseApiTestCase
 		// create active notifications
 		Notification::factory()->create();
 		// create expired notification which should not be included
-        Notification::factory()->expired()->create();
+		Notification::factory()->expired()->create();
 
         $response = $this->makeAuthenticatedApiRequest('GET', $this->baseEndpoint);
 

--- a/tests/app/Http/Controllers/Admin/NotificationAdminControllerTest.php
+++ b/tests/app/Http/Controllers/Admin/NotificationAdminControllerTest.php
@@ -1,0 +1,224 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\BaseApiTestCase;
+use App\Models\Controller\ControllerPosition;
+use App\Models\Notification\Notification;
+use App\Providers\AuthServiceProvider;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class NotificationAdminControllerTest extends BaseApiTestCase
+{
+    use DatabaseTransactions;
+
+	protected static $tokenScope = [
+		AuthServiceProvider::SCOPE_DATA_ADMIN
+	];
+
+	protected string $baseEndpoint = "admin/notifications";
+
+	public function testActiveNotificationsCanBeRetrievedByDefault()
+	{
+		// create active notifications
+		Notification::factory()->create();
+		// create expired notification which should not be included
+        Notification::factory()->expired()->create();
+
+        $response = $this->makeAuthenticatedApiRequest('GET', $this->baseEndpoint);
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure(['notifications']);
+		// test expired notification not included by default.
+        $response->assertJsonCount(1, 'notifications');
+	}
+	
+	public function testActiveAndExpiredNotificationsCanBeRetrieved()
+	{
+		// create active notifications
+		Notification::factory()->create();
+		// create expired notification which should be included 
+        Notification::factory()->expired()->create();
+
+        $response = $this->makeAuthenticatedApiRequest('GET', "{$this->baseEndpoint}?include_expired=true");
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure(['notifications']);
+		// test expired notification not included by default.
+        $response->assertJsonCount(2, 'notifications');
+	}
+
+	public function testIndividualNotificationCanBeRetrieved()
+	{
+        $notification = Notification::factory()->create();
+
+        $response = $this->makeAuthenticatedApiRequest('GET', "{$this->baseEndpoint}/{$notification->id}");
+
+        $response->assertSuccessful();
+		$response->assertJson([
+			'notification' => [
+				...$notification->attributesToArray(),
+				// assert controllers are added in full at the positions key.
+				'positions' => $notification->controllers->toArray()
+			]
+		]);
+	}
+
+	public function testBadRequestWhenInvalidPositionGiven()
+	{
+        $invalidPositions = [9999999];
+		$response = $this->makeAuthenticatedApiRequest('POST', $this->baseEndpoint,
+			$this->generateNotificationBody(['positions' => $invalidPositions])
+		);
+
+        $response->assertStatus(400);
+        $response->assertJson(['message' => 'Invalid positions.']);
+	}
+
+	/** @test */
+	public function testAllowsCreationOfNotification()
+	{
+		// create a valid position to create the notification with.
+        $position = ControllerPosition::factory()->create();
+		
+		$body = [
+            ...$this->generateNotificationBody(['positions' => [$position->id]]),
+			'all_positions' => false,
+		];
+
+		$response = $this->makeAuthenticatedApiRequest("POST", $this->baseEndpoint, $body);
+
+        $response->assertStatus(201);
+        $response->assertJsonStructure(['notification_id']);
+	}
+
+	public function testAllowsCreationOfNotificationAgainstAllPositions()
+	{
+		$body = $this->generateNotificationBody(['all_positions' => true]);
+
+		$response = $this->makeAuthenticatedApiRequest("POST", $this->baseEndpoint, $body);
+
+        $response->assertStatus(201);
+        $response->assertJsonStructure(['notification_id']);
+
+        $createdNotification = Notification::findOrFail((int) $response->json('notification_id'));
+
+		// assert number of allocated positions is equal to all stored positions
+        $this->assertEquals(
+			$createdNotification->controllers->count(),
+			ControllerPosition::count()
+		);
+	}
+
+	/** @test */
+	public function testIgnoresPositionFieldWhenAllPositionsSpecified()
+	{
+		// create a valid position to create the notification with.
+		$position = ControllerPosition::factory()->create();
+		$body = [
+            ...$this->generateNotificationBody(['positions' => [$position->id]]),
+			'all_positions' => true,
+		];	
+
+		$response = $this->makeAuthenticatedApiRequest("POST", $this->baseEndpoint, $body);
+
+        $response->assertStatus(201);
+
+		$response->assertJsonStructure(['notification_id']);
+
+        $createdNotification = Notification::findOrFail((int) $response->json('notification_id'));
+
+		// assert number of allocated positions is equal to all stored positions
+        $this->assertEquals(
+			$createdNotification->controllers->count(),
+			ControllerPosition::count()
+		);
+	}
+
+	/** @dataProvider notificationValidationDataProvider */
+	public function testValidatorForNotifications($value, $key, $errorsExpected)
+	{
+        $response = $this->makeAuthenticatedApiRequest(
+			"POST", $this->baseEndpoint, 
+			// merge with fake valid notification body to isolate errors
+			// from data provider.
+			$this->generateNotificationBody([$key => $value])
+		);
+
+		if ($errorsExpected) {
+            $response->assertStatus(422);
+            $response->assertJsonValidationErrorFor($key);
+		} else {
+            $response->assertSuccessful();
+            $response->assertJsonMissingValidationErrors($key);
+		}
+	}
+
+	public function testValidatesToDateAfterFromDate()
+	{
+		$response = $this->makeAuthenticatedApiRequest(
+			"POST", $this->baseEndpoint,
+			$this->generateNotificationBody([
+				'valid_from' => Carbon::now()->toIso8601String(),
+				'valid_to' => Carbon::now()->subHour()->toIso8601String()
+			])
+		);
+
+        $response->assertJsonValidationErrorFor('valid_to');
+	}
+	
+	public function testValidatesFromDateBeforeToDate()
+	{
+		$response = $this->makeAuthenticatedApiRequest(
+			"POST", $this->baseEndpoint,
+			$this->generateNotificationBody([
+				'valid_from' => Carbon::now()->addHour()->toIso8601String(),
+				'valid_to' => Carbon::now()->toIso8601String()
+			])
+		);
+
+        $response->assertJsonValidationErrorFor('valid_from');
+	}
+	
+	public function testNotificationCanBeDeleted()
+	{
+        $notification = Notification::factory()->create();
+
+		$response = $this->makeAuthenticatedApiRequest(
+			"DELETE", "{$this->baseEndpoint}/{$notification->id}"
+		);
+
+        $response->assertStatus(204);
+        $this->assertSoftDeleted('notifications', ['id' => $notification->id]);
+	}
+
+	private function notificationValidationDataProvider() : array // NOSONAR
+	{
+		return [
+			['not-a-url', 'link', true],
+			['https://google.com', 'link', false],
+			['', 'title', true],
+			['This is a valid title', 'title', false],
+			['', 'body', true],
+			['This is a valid body', 'body', false],
+			['', 'valid_from', true],
+			['not-a-date', 'valid_from', true],
+			['', 'valid_to', true],
+			['not-a-date', 'valid_to', true],
+		];
+	}
+
+	private function generateNotificationBody($overrides = []) : array 
+	{
+		return array_merge(
+			Notification::factory()->make(
+				[
+					'valid_from' => Carbon::now(), 
+					'valid_to' => Carbon::now()->addHours(2)
+				]
+			)->toArray(),
+			$overrides
+		);
+	}
+}

--- a/tests/app/Http/Controllers/Admin/NotificationAdminControllerTest.php
+++ b/tests/app/Http/Controllers/Admin/NotificationAdminControllerTest.php
@@ -197,7 +197,6 @@ class NotificationAdminControllerTest extends BaseApiTestCase
 	{
 		return [
 			['not-a-url', 'link', true],
-			['https://google.com', 'link', false],
 			['', 'title', true],
 			['This is a valid title', 'title', false],
 			['', 'body', true],


### PR DESCRIPTION
Adds endpoints for administering notifications to lay the ground work for a tool which Ops can use to
create UKCP notifications without intervention from the web team.

A PATCH/PUT endpoint has been deliberatley omitted at this time as mistakes can just be deleted.

An additional utility endpoint is included as part of this change to list the positions available for allocation
against a newly created notification.
