### PR TITLE
feat(stand): Allocate stands based on airline callsigns, add UKV preferred

### DIFF
--- a/app/Allocator/Stand/AirlineArrivalStandAllocator.php
+++ b/app/Allocator/Stand/AirlineArrivalStandAllocator.php
@@ -22,6 +22,7 @@ class AirlineArrivalStandAllocator extends AbstractArrivalStandAllocator
             ? null
             : $stands->airline($airline)
                 ->orderByRaw('airline_stand.destination IS NULL DESC')
+                ->orderByRaw('airline_stand.callsign_slug IS NULL DESC')
                 ->orderBy('airline_stand.priority');
     }
 }

--- a/app/Allocator/Stand/AirlineCallsignSlugArrivalStandAllocator.php
+++ b/app/Allocator/Stand/AirlineCallsignSlugArrivalStandAllocator.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Allocator\Stand;
+
+use App\Models\Vatsim\NetworkAircraft;
+use App\Services\AirlineService;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Str;
+
+class AirlineCallsignSlugArrivalStandAllocator extends AbstractArrivalStandAllocator
+{
+    private AirlineService $airlineService;
+
+    public function __construct(AirlineService $airlineService)
+    {
+        $this->airlineService = $airlineService;
+    }
+
+    protected function getOrderedStandsQuery(Builder $stands, NetworkAircraft $aircraft): ?Builder
+    {
+        $airline = $this->airlineService->getAirlineForAircraft($aircraft);
+        if ($airline === null) {
+            return null;
+        }
+
+        return $stands->with('airlines')
+            ->airlineCallsign($airline, $this->getCallsignSlugs($aircraft))
+            ->orderByRaw('airline_stand.callsign_slug IS NOT NULL')
+            ->orderByRaw('LENGTH(airline_stand.callsign_slug) DESC')
+            ->orderBy('airline_stand.priority');
+    }
+
+    public function getCallsignSlugs(NetworkAircraft $aircraft): array
+    {
+        $slug = $this->airlineService->getCallsignSlugForAircraft($aircraft);
+        $slugs = [];
+        for ($i = 0; $i < Str::length($slug); $i++) {
+            $slugs[] = Str::substr($slug, 0, $i + 1);
+        }
+
+        return $slugs;
+    }
+}

--- a/app/Models/Airline/Airline.php
+++ b/app/Models/Airline/Airline.php
@@ -3,6 +3,7 @@
 namespace App\Models\Airline;
 
 use App\Models\Airfield\Terminal;
+use App\Models\Stand\Stand;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
@@ -22,5 +23,10 @@ class Airline extends Model
     public function terminals(): BelongsToMany
     {
         return $this->belongsToMany(Terminal::class)->withTimestamps();
+    }
+
+    public function stands(): BelongsToMany
+    {
+        return $this->belongsToMany(Stand::class)->withTimestamps();
     }
 }

--- a/app/Models/Stand/Stand.php
+++ b/app/Models/Stand/Stand.php
@@ -75,7 +75,7 @@ class Stand extends Model
             'airline_stand',
             'stand_id',
             'airline_id'
-        )->withPivot('destination', 'priority', 'not_before')->withTimestamps();
+        )->withPivot('destination', 'priority', 'not_before', 'callsign_slug')->withTimestamps();
     }
 
     public function getCoordinateAttribute()
@@ -131,6 +131,11 @@ class Stand extends Model
     public function scopeAirlineDestination(Builder $builder, Airline $airline, array $destinationStrings): Builder
     {
         return $this->scopeAirline($builder, $airline)->whereIn('destination', $destinationStrings);
+    }
+
+    public function scopeAirlineCallsign(Builder $builder, Airline $airline, array $slugs): Builder
+    {
+        return $this->scopeAirline($builder, $airline)->whereIn('callsign_slug', $slugs);
     }
 
     public function wakeCategory(): BelongsTo

--- a/app/Providers/StandServiceProvider.php
+++ b/app/Providers/StandServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Allocator\Stand\AirlineCallsignSlugArrivalStandAllocator;
 use App\Allocator\Stand\CargoFlightPreferredArrivalStandAllocator;
 use App\Allocator\Stand\CargoFlightArrivalStandAllocator;
 use App\Allocator\Stand\CidReservedArrivalStandAllocator;
@@ -32,6 +33,7 @@ class StandServiceProvider extends ServiceProvider
                     $application->make(CallsignFlightplanReservedArrivalStandAllocator::class),
                     $application->make(CargoFlightPreferredArrivalStandAllocator::class),
                     $application->make(CargoFlightArrivalStandAllocator::class),
+                    $application->make(AirlineCallsignSlugArrivalStandAllocator::class),
                     $application->make(AirlineDestinationArrivalStandAllocator::class),
                     $application->make(AirlineArrivalStandAllocator::class),
                     $application->make(AirlineTerminalArrivalStandAllocator::class),

--- a/app/Services/AirlineService.php
+++ b/app/Services/AirlineService.php
@@ -4,11 +4,20 @@ namespace App\Services;
 
 use App\Models\Airline\Airline;
 use App\Models\Vatsim\NetworkAircraft;
+use Illuminate\Support\Str;
 
 class AirlineService
 {
     public function getAirlineForAircraft(NetworkAircraft $aircraft): ?Airline
     {
-        return Airline::where('icao_code', substr($aircraft->callsign, 0, 3))->first();
+        return Airline::where('icao_code', Str::substr($aircraft->callsign, 0, 3))->first();
+    }
+
+    public function getCallsignSlugForAircraft(NetworkAircraft $aircraft): string
+    {
+        $airline = $this->getAirlineForAircraft($aircraft);
+        return $airline
+            ? Str::substr($aircraft->callsign, 3)
+            : $aircraft->callsign;
     }
 }

--- a/database/migrations/2022_02_28_173512_add_fly_uk_airline.php
+++ b/database/migrations/2022_02_28_173512_add_fly_uk_airline.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Models\Airline\Airline;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddFlyUkAirline extends Migration
+{
+    private const ICAO_CODE = 'UKV';
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Airline::create(
+            [
+                'icao_code' => self::ICAO_CODE,
+                'name' => 'FlyUK (Virtual)',
+                'callsign' => 'Skyways',
+                'is_cargo' => false,
+            ]
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Airline::where('icao_code', self::ICAO_CODE)->delete();
+    }
+}

--- a/database/migrations/2022_02_28_173819_add_callsign_slug_to_airline_stand_table.php
+++ b/database/migrations/2022_02_28_173819_add_callsign_slug_to_airline_stand_table.php
@@ -16,6 +16,7 @@ class AddCallsignSlugToAirlineStandTable extends Migration
         Schema::table('airline_stand', function (Blueprint $table) {
             $table->string('callsign_slug')
                 ->nullable()
+                ->after('destination')
                 ->index()
                 ->comment('Prefer this stand for callsigns matching the slug');
         });

--- a/database/migrations/2022_02_28_173819_add_callsign_slug_to_airline_stand_table.php
+++ b/database/migrations/2022_02_28_173819_add_callsign_slug_to_airline_stand_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddCallsignSlugToAirlineStandTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('airline_stand', function (Blueprint $table) {
+            $table->string('callsign_slug')
+                ->nullable()
+                ->index()
+                ->comment('Prefer this stand for callsigns matching the slug');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('airline_stand', function (Blueprint $table) {
+            $table->dropColumn('callsign_slug');
+        });
+    }
+}

--- a/database/migrations/2022_02_28_174007_fly_uk_stand_assignments.php
+++ b/database/migrations/2022_02_28_174007_fly_uk_stand_assignments.php
@@ -1,0 +1,380 @@
+<?php
+
+use App\Models\Airfield\Airfield;
+use App\Models\Airfield\Terminal;
+use App\Models\Airline\Airline;
+use App\Models\Stand\Stand;
+use Illuminate\Database\Migrations\Migration;
+
+class FlyUkStandAssignments extends Migration
+{
+    const TERMINALS = [
+        'EGLL_T2A',
+        'EGLL_T2B',
+    ];
+
+    const STANDS_MAINSTREAM = [
+        'EGKK' => [
+            '46',
+            '47',
+            '47L',
+            '47R',
+            '48',
+            '48L',
+            '48R',
+            '49',
+            '49L',
+            '49R',
+            '50',
+            '51',
+            '51L',
+            '51R',
+            '52',
+            '52L',
+            '52R',
+            '53',
+            '54',
+            '101',
+            '102',
+            '103',
+            '104',
+            '105',
+            '106',
+            '107',
+            '109',
+            '110',
+            '110L',
+            '110R',
+            '111',
+            '112',
+            '113',
+        ],
+        'EGCC' => [
+            '50',
+            '51',
+            '52',
+            '53',
+        ],
+        'EGPH' => [
+            '4',
+            '5',
+            '6',
+            '7',
+            '8',
+            '9',
+            '10',
+        ],
+        'EGLC' => [
+            '9',
+            '10',
+            '11',
+            '12',
+        ],
+        'EGBB' => [
+            '40',
+            '40L',
+            '41C',
+            '41L',
+            '41R',
+            '42C',
+            '42L',
+            '42R',
+            '54C',
+            '54L',
+            '54R',
+            '55C',
+            '55L',
+            '55R',
+            '56C',
+            '56L',
+            '56R',
+        ],
+        'EGHI' => [
+            '1',
+            '2',
+            '3',
+            '4',
+            '5',
+        ],
+        'EGSS' => [
+            '20',
+            '21',
+            '22L',
+            '22R',
+            '22',
+            '23',
+            '23L',
+            '23R',
+        ],
+        'EGPF' => [
+            '27',
+            '28',
+            '29',
+            '30',
+            '31',
+            '32',
+            '33',
+            '34',
+            '35',
+            '36',
+        ],
+        'EGGD' => [
+            '1',
+            '2',
+        ],
+        'EGFF' => [
+            '9',
+            '10',
+        ],
+        'EGGW' => [
+            '6',
+            '7',
+            '8',
+            '9',
+        ],
+        'EGNM' => [
+            '7',
+            '8',
+        ],
+        'EGAA' => [
+            '15',
+            '16',
+            '21',
+            '22',
+        ],
+        'EGJJ' => [
+            '9',
+            '10',
+        ],
+    ];
+
+    const STANDS_MAINSTREAM_DOMESTIC = [
+        'EGCC' => [
+            '4',
+            '5',
+            '6',
+            '7',
+            '8',
+            '9',
+            '10',
+            '11',
+            '22',
+            '23',
+            '24',
+            '25',
+            '26',
+            '27',
+        ],
+        'EGPH' => [
+            '19',
+            '20',
+            '21',
+            '22',
+            '23',
+            '24',
+        ],
+        'EGPF' => [
+            '14',
+            '15',
+            '16',
+            '17',
+            '18',
+        ],
+        'EGNM' => [
+            '9',
+        ],
+    ];
+
+    const STANDS_FLY2 = [
+        'EGCC' => [
+            '202',
+            '204',
+            '206',
+            '207',
+            '208',
+            '209',
+            '210',
+            '211',
+            '212',
+            '213',
+            '214',
+            '215',
+            '216',
+            '217',
+            '218',
+        ],
+        'EGBB' => [
+            '13',
+            '14',
+            '15',
+        ],
+        'EGPF' => [
+            '27',
+            '28',
+            '29',
+            '30',
+            '31',
+            '32',
+            '33',
+            '34',
+            '35',
+            '36',
+        ],
+        'EGNM' => [
+            '7',
+            '8',
+            '10',
+            '11',
+        ],
+    ];
+
+    const STANDS_HIGHLAND_CONNECT = [
+        'EGPH' => [
+            '101',
+            '102',
+            '103',
+            '104',
+        ],
+        'EGPF' => [
+            '1',
+            '2',
+            '12',
+        ],
+    ];
+
+    const STANDS_CARGO = [
+        'EGSS' => [
+            '1',
+            '1L',
+            '1R',
+            '2',
+            '3',
+            '4',
+        ],
+    ];
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $airline = Airline::where('icao_code', 'UKV')->firstOrFail();
+        $this->setTerminals($airline);
+        $this->setMainstreamStands($airline);
+        $this->setMainstreamDomesticStands($airline);
+        $this->setFly2Stands($airline);
+        $this->setHighlandConnectStands($airline);
+        $this->setCargoStands($airline);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+
+    private function setTerminals(Airline $airline): void
+    {
+        $airline->terminals()->sync(Terminal::whereIn('key', self::TERMINALS)->pluck('id'));
+    }
+
+    private function setMainstreamStands(Airline $airline): void
+    {
+        foreach (self::STANDS_MAINSTREAM as $airfield => $stands) {
+            $this->insertStands(
+                $airline,
+                $airfield,
+                $stands,
+                fn(Stand $stand) => [
+                    $stand->id => [
+                        'airline_id' => $airline->id,
+                    ]
+                ]
+            );
+        }
+    }
+
+    private function setMainstreamDomesticStands(Airline $airline): void
+    {
+        foreach (self::STANDS_MAINSTREAM_DOMESTIC as $airfield => $stands) {
+            $this->insertStands(
+                $airline,
+                $airfield,
+                $stands,
+                fn(Stand $stand) => [
+                    $stand->id => [
+                        'airline_id' => $airline->id,
+                        'destination' => 'EG',
+                    ]
+                ]
+            );
+        }
+    }
+
+    private function setFly2Stands(Airline $airline): void
+    {
+        foreach (self::STANDS_FLY2 as $airfield => $stands) {
+            $this->insertStands(
+                $airline,
+                $airfield,
+                $stands,
+                fn(Stand $stand) => [
+                    $stand->id => [
+                        'airline_id' => $airline->id,
+                        'callsign_slug' => '2',
+                    ]
+                ]
+            );
+        }
+    }
+
+    private function setHighlandConnectStands(Airline $airline): void
+    {
+        foreach (self::STANDS_HIGHLAND_CONNECT as $airfield => $stands) {
+            $this->insertStands(
+                $airline,
+                $airfield,
+                $stands,
+                fn(Stand $stand) => [
+                    $stand->id => [
+                        'airline_id' => $airline->id,
+                        'callsign_slug' => '4',
+                    ]
+                ]
+            );
+        }
+    }
+
+    private function setCargoStands(Airline $airline): void
+    {
+        foreach (self::STANDS_CARGO as $airfield => $stands) {
+            $this->insertStands(
+                $airline,
+                $airfield,
+                $stands,
+                fn(Stand $stand) => [
+                    $stand->id => [
+                        'airline_id' => $airline->id,
+                        'callsign_slug' => '7',
+                    ]
+                ]
+            );
+        }
+    }
+
+    private function insertStands(Airline $airline, string $airfield, array $stands, callable $mapFunction): void
+    {
+        $standsToInsert = Stand::whereIn('identifier', $stands)
+            ->airfield($airfield)
+            ->get()
+            ->mapWithKeys($mapFunction)
+            ->toArray();
+        $airline->stands()->attach($standsToInsert);
+    }
+}

--- a/database/migrations/2022_02_28_174007_fly_uk_stand_assignments.php
+++ b/database/migrations/2022_02_28_174007_fly_uk_stand_assignments.php
@@ -291,7 +291,7 @@ class FlyUkStandAssignments extends Migration
                 $airline,
                 $airfield,
                 $stands,
-                fn(Stand $stand) => [
+                fn (Stand $stand) => [
                     $stand->id => [
                         'airline_id' => $airline->id,
                     ]
@@ -307,7 +307,7 @@ class FlyUkStandAssignments extends Migration
                 $airline,
                 $airfield,
                 $stands,
-                fn(Stand $stand) => [
+                fn (Stand $stand) => [
                     $stand->id => [
                         'airline_id' => $airline->id,
                         'destination' => 'EG',
@@ -324,7 +324,7 @@ class FlyUkStandAssignments extends Migration
                 $airline,
                 $airfield,
                 $stands,
-                fn(Stand $stand) => [
+                fn (Stand $stand) => [
                     $stand->id => [
                         'airline_id' => $airline->id,
                         'callsign_slug' => '2',
@@ -341,7 +341,7 @@ class FlyUkStandAssignments extends Migration
                 $airline,
                 $airfield,
                 $stands,
-                fn(Stand $stand) => [
+                fn (Stand $stand) => [
                     $stand->id => [
                         'airline_id' => $airline->id,
                         'callsign_slug' => '4',
@@ -358,7 +358,7 @@ class FlyUkStandAssignments extends Migration
                 $airline,
                 $airfield,
                 $stands,
-                fn(Stand $stand) => [
+                fn (Stand $stand) => [
                     $stand->id => [
                         'airline_id' => $airline->id,
                         'callsign_slug' => '7',

--- a/tests/app/Allocator/Stand/AirlineCallsignSlugStandAllocatorTest.php
+++ b/tests/app/Allocator/Stand/AirlineCallsignSlugStandAllocatorTest.php
@@ -1,0 +1,504 @@
+<?php
+
+namespace App\Allocator\Stand;
+
+use App\BaseFunctionalTestCase;
+use App\Models\Aircraft\WakeCategory;
+use App\Models\Stand\Stand;
+use App\Models\Stand\StandAssignment;
+use App\Models\Vatsim\NetworkAircraft;
+use Illuminate\Support\Facades\DB;
+use util\Traits\WithWakeCategories;
+
+class AirlineCallsignSlugStandAllocatorTest extends BaseFunctionalTestCase
+{
+    use WithWakeCategories;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->allocator = $this->app->make(AirlineCallsignSlugArrivalStandAllocator::class);
+    }
+
+    public function testItAllocatesAStandWithAFixedCallsignSlug()
+    {
+        DB::table('airline_stand')->insert(
+            [
+                [
+                    'airline_id' => 1,
+                    'stand_id' => 1,
+                    'callsign_slug' => null
+                ],
+                [
+                    'airline_id' => 1,
+                    'stand_id' => 2,
+                    'callsign_slug' => '23451'
+                ],
+                [
+                    'airline_id' => 1,
+                    'stand_id' => 3,
+                    'callsign_slug' => null
+                ],
+                [
+                    'airline_id' => 2,
+                    'stand_id' => 1,
+                    'callsign_slug' => '23451'
+                ],
+            ]
+        );
+        $aircraft = $this->createAircraft('BAW23451', 'EGLL', 'EGGD');
+        $this->assertEquals(2, $this->allocator->allocate($aircraft)->stand_id);
+        $this->assertEquals(2, StandAssignment::find($aircraft->callsign)->stand_id);
+    }
+
+    public function testItConsidersAirlinePreferences()
+    {
+        DB::table('airline_stand')->insert(
+            [
+                [
+                    'airline_id' => 1,
+                    'stand_id' => 1,
+                    'callsign_slug' => '23451',
+                    'priority' => 100,
+                ],
+                [
+                    'airline_id' => 1,
+                    'stand_id' => 2,
+                    'callsign_slug' => '23451',
+                    'priority' => 3,
+                ],
+                [
+                    'airline_id' => 1,
+                    'stand_id' => 3,
+                    'callsign_slug' => '23451',
+                    'priority' => 2,
+                ],
+                [
+                    'airline_id' => 2,
+                    'stand_id' => 1,
+                    'callsign_slug' => '23451',
+                    'priority' => 1,
+                ],
+            ]
+        );
+        $aircraft = $this->createAircraft('BAW23451', 'EGLL', 'EGGD');
+        $this->assertEquals(2, $this->allocator->allocate($aircraft)->stand_id);
+        $this->assertEquals(2, StandAssignment::find($aircraft->callsign)->stand_id);
+    }
+
+    public function testItAllocatesAStandWithAnAppropriateWeight()
+    {
+        $this->setWakeCategoryForAircraft('B738', 'UM');
+        $weightAppropriateStand = Stand::create(
+            [
+                'airfield_id' => 1,
+                'identifier' => '502',
+                'latitude' => 54.65875500,
+                'longitude' => -6.22258694,
+                'wake_category_id' => WakeCategory::where('code', 'UM')->first()->id,
+            ]
+        );
+        DB::table('airline_stand')->insert(
+            [
+                [
+                    'airline_id' => 1,
+                    'stand_id' => 1,
+                    'callsign_slug' => null
+                ],
+                [
+                    'airline_id' => 1,
+                    'stand_id' => 2,
+                    'callsign_slug' => '23451'
+                ],
+                [
+                    'airline_id' => 1,
+                    'stand_id' => 3,
+                    'callsign_slug' => null
+                ],
+                [
+                    'airline_id' => 2,
+                    'stand_id' => 1,
+                    'callsign_slug' => '23451'
+                ],
+                [
+                    'airline_id' => 1,
+                    'stand_id' => $weightAppropriateStand->id,
+                    'callsign_slug' => '23451'
+                ],
+            ]
+        );
+        $aircraft = $this->createAircraft('BAW23451', 'EGLL', 'EGGD');
+        $this->assertEquals($weightAppropriateStand->id, $this->allocator->allocate($aircraft)->stand_id);
+        $this->assertEquals($weightAppropriateStand->id, StandAssignment::find($aircraft->callsign)->stand_id);
+    }
+
+    public function testItAllocatesAStandInWeightAscendingOrder()
+    {
+        $this->setWakeCategoryForAircraft('B738', 'S');
+        $weightAppropriateStand = Stand::create(
+            [
+                'airfield_id' => 1,
+                'identifier' => '502',
+                'latitude' => 54.65875500,
+                'longitude' => -6.22258694,
+                'wake_category_id' => WakeCategory::where('code', 'S')->first()->id,
+            ]
+        );
+        DB::table('airline_stand')->insert(
+            [
+                [
+                    'airline_id' => 1,
+                    'stand_id' => 1,
+                    'callsign_slug' => null
+                ],
+                [
+                    'airline_id' => 1,
+                    'stand_id' => 2,
+                    'callsign_slug' => '23451'
+                ],
+                [
+                    'airline_id' => 1,
+                    'stand_id' => 3,
+                    'callsign_slug' => null
+                ],
+                [
+                    'airline_id' => 2,
+                    'stand_id' => 1,
+                    'callsign_slug' => '23451'
+                ],
+                [
+                    'airline_id' => 1,
+                    'stand_id' => $weightAppropriateStand->id,
+                    'callsign_slug' => '23451'
+                ],
+            ]
+        );
+        $aircraft = $this->createAircraft('BAW23451', 'EGLL', 'EGGD');
+        $this->assertEquals($weightAppropriateStand->id, $this->allocator->allocate($aircraft)->stand_id);
+        $this->assertEquals($weightAppropriateStand->id, StandAssignment::find($aircraft->callsign)->stand_id);
+    }
+
+    public function testItAllocatesSingleCharacterMatches()
+    {
+        DB::table('airline_stand')->insert(
+            [
+                [
+                    'airline_id' => 1,
+                    'stand_id' => 2,
+                    'callsign_slug' => null
+                ],
+                [
+                    'airline_id' => 1,
+                    'stand_id' => 1,
+                    'callsign_slug' => '2'
+                ],
+            ]
+        );
+        $aircraft = $this->createAircraft('BAW23451', 'EGLL', 'EGGD');
+        $this->assertEquals(1, $this->allocator->allocate($aircraft)->stand_id);
+        $this->assertEquals(1, StandAssignment::find($aircraft->callsign)->stand_id);
+    }
+
+    public function testItPrefersDoubleCharacterMatches()
+    {
+        $doubleCharacterStand = Stand::create(
+            [
+                'identifier' => '999',
+                'airfield_id' => 1,
+                'latitude' => 0,
+                'longitude' => 0,
+            ]
+        );
+
+        DB::table('airline_stand')->insert(
+            [
+                [
+                    'airline_id' => 1,
+                    'stand_id' => 2,
+                    'callsign_slug' => null
+                ],
+                [
+                    'airline_id' => 1,
+                    'stand_id' => 1,
+                    'callsign_slug' => '2'
+                ],
+                [
+                    'airline_id' => 1,
+                    'stand_id' => $doubleCharacterStand->id,
+                    'callsign_slug' => '23'
+                ],
+            ]
+        );
+        $aircraft = $this->createAircraft('BAW23451', 'EGLL', 'EGGD');
+        $this->assertEquals($doubleCharacterStand->id, $this->allocator->allocate($aircraft)->stand_id);
+        $this->assertEquals($doubleCharacterStand->id, StandAssignment::find($aircraft->callsign)->stand_id);
+    }
+
+    public function testItPrefersTripleCharacterMatches()
+    {
+        $doubleCharacterStand = Stand::create(
+            [
+                'identifier' => '999',
+                'airfield_id' => 1,
+                'latitude' => 0,
+                'longitude' => 0,
+            ]
+        );
+
+        $tripleCharacterStand = Stand::create(
+            [
+                'identifier' => '888',
+                'airfield_id' => 1,
+                'latitude' => 0,
+                'longitude' => 0,
+            ]
+        );
+
+        DB::table('airline_stand')->insert(
+            [
+                [
+                    'airline_id' => 1,
+                    'stand_id' => 2,
+                    'callsign_slug' => null
+                ],
+                [
+                    'airline_id' => 1,
+                    'stand_id' => 1,
+                    'callsign_slug' => '2'
+                ],
+                [
+                    'airline_id' => 1,
+                    'stand_id' => $doubleCharacterStand->id,
+                    'callsign_slug' => '23'
+                ],
+                [
+                    'airline_id' => 1,
+                    'stand_id' => $tripleCharacterStand->id,
+                    'callsign_slug' => '234'
+                ],
+            ]
+        );
+        $aircraft = $this->createAircraft('BAW23451', 'EGLL', 'EGGD');
+        $this->assertEquals($tripleCharacterStand->id, $this->allocator->allocate($aircraft)->stand_id);
+        $this->assertEquals($tripleCharacterStand->id, StandAssignment::find($aircraft->callsign)->stand_id);
+    }
+
+    public function testItPrefersFullMatches()
+    {
+        $doubleCharacterStand = Stand::create(
+            [
+                'identifier' => '999',
+                'airfield_id' => 1,
+                'latitude' => 0,
+                'longitude' => 0,
+            ]
+        );
+
+        $tripleCharacterStand = Stand::create(
+            [
+                'identifier' => '888',
+                'airfield_id' => 1,
+                'latitude' => 0,
+                'longitude' => 0,
+            ]
+        );
+
+        $fullMatchStand = Stand::create(
+            [
+                'identifier' => '777',
+                'airfield_id' => 1,
+                'latitude' => 0,
+                'longitude' => 0,
+            ]
+        );
+
+        DB::table('airline_stand')->insert(
+            [
+                [
+                    'airline_id' => 1,
+                    'stand_id' => 2,
+                    'callsign_slug' => null
+                ],
+                [
+                    'airline_id' => 1,
+                    'stand_id' => 1,
+                    'callsign_slug' => '2'
+                ],
+                [
+                    'airline_id' => 1,
+                    'stand_id' => $doubleCharacterStand->id,
+                    'callsign_slug' => '23'
+                ],
+                [
+                    'airline_id' => 1,
+                    'stand_id' => $tripleCharacterStand->id,
+                    'callsign_slug' => '2345'
+                ],
+                [
+                    'airline_id' => 1,
+                    'stand_id' => $fullMatchStand->id,
+                    'callsign_slug' => '23451'
+                ],
+            ]
+        );
+        $aircraft = $this->createAircraft('BAW23451', 'EGLL', 'EGGD');
+        $this->assertEquals($fullMatchStand->id, $this->allocator->allocate($aircraft)->stand_id);
+        $this->assertEquals($fullMatchStand->id, StandAssignment::find($aircraft->callsign)->stand_id);
+    }
+
+    public function testItDoesntAllocateOccupiedStands()
+    {
+        DB::table('airline_stand')->insert(
+            [
+                [
+                    'airline_id' => 1,
+                    'stand_id' => 1,
+                    'callsign_slug' => '23451'
+                ],
+                [
+                    'airline_id' => 1,
+                    'stand_id' => 2,
+                    'callsign_slug' => '23451'
+                ],
+                [
+                    'airline_id' => 1,
+                    'stand_id' => 3,
+                    'callsign_slug' => null
+                ],
+                [
+                    'airline_id' => 2,
+                    'stand_id' => 1,
+                    'callsign_slug' => '23451'
+                ],
+            ]
+        );
+
+        $occupier = $this->createAircraft('EZY7823', 'EGLL', 'EGGD');
+        $occupier->occupiedStand()->sync([1]);
+        $aircraft = $this->createAircraft('BAW23451', 'EGLL', 'EGGD');
+        $this->assertEquals(2, $this->allocator->allocate($aircraft)->stand_id);
+        $this->assertEquals(2, StandAssignment::find($aircraft->callsign)->stand_id);
+    }
+
+    public function testItDoesntAllocateAStandWithNoDestination()
+    {
+        DB::table('airline_stand')->insert(
+            [
+                [
+                    'airline_id' => 1,
+                    'stand_id' => 2,
+                    'callsign_slug' => null
+                ],
+                [
+                    'airline_id' => 1,
+                    'stand_id' => 1,
+                    'callsign_slug' => null
+                ],
+                [
+                    'airline_id' => 2,
+                    'stand_id' => 1,
+                    'callsign_slug' => '23451'
+                ],
+            ]
+        );
+        $aircraft = $this->createAircraft('BAW23451', 'EGLL', 'EGGD');
+        $this->assertNull($this->allocator->allocate($aircraft));
+        $this->assertNull(StandAssignment::find($aircraft->callsign));
+    }
+
+    public function testItDoesntAllocateAtTheWrongAirfield()
+    {
+        DB::table('airline_stand')->insert(
+            [
+                [
+                    'airline_id' => 1,
+                    'stand_id' => 3,
+                    'callsign_slug' => '23451'
+                ],
+                [
+                    'airline_id' => 2,
+                    'stand_id' => 1,
+                    'callsign_slug' => '23451'
+                ],
+            ]
+        );
+        $aircraft = $this->createAircraft('BAW23451', 'EGLL', 'EGGD');
+        $this->assertNull($this->allocator->allocate($aircraft));
+        $this->assertNull(StandAssignment::find($aircraft->callsign));
+    }
+
+    public function testItDoesntAllocateForTheWrongCallsign()
+    {
+        DB::table('airline_stand')->insert(
+            [
+                [
+                    'airline_id' => 2,
+                    'stand_id' => 1,
+                    'callsign_slug' => '5'
+                ],
+            ]
+        );
+        $aircraft = $this->createAircraft('BAW23451', 'EGLL', 'EGGD');
+        $this->assertNull($this->allocator->allocate($aircraft));
+        $this->assertNull(StandAssignment::find($aircraft->callsign));
+    }
+
+    public function testItDoesntAllocateUnavailableStands()
+    {
+        DB::table('airline_stand')->insert(
+            [
+                [
+                    'airline_id' => 1,
+                    'stand_id' => 1,
+                    'callsign_slug' => '23451'
+                ],
+                [
+                    'airline_id' => 1,
+                    'stand_id' => 2,
+                    'callsign_slug' => '23451'
+                ],
+            ]
+        );
+        NetworkAircraft::find('BAW123')->occupiedStand()->sync([1]);
+
+        $aircraft = $this->createAircraft('BAW23451', 'EGLL', 'EGGD');
+        $this->assertEquals(2, $this->allocator->allocate($aircraft)->stand_id);
+        $this->assertEquals(2, StandAssignment::find($aircraft->callsign)->stand_id);
+    }
+
+    public function testItDoesntAllocateNonExistentAirlines()
+    {
+        DB::table('airline_stand')->insert(
+            [
+                [
+                    'airline_id' => 1,
+                    'stand_id' => 3,
+                    'callsign_slug' => '23451'
+                ],
+                [
+                    'airline_id' => 2,
+                    'stand_id' => 1,
+                    'callsign_slug' => '23451'
+                ],
+            ]
+        );
+        $aircraft = $this->createAircraft('***1234', 'EGLL', 'EGGD');
+        $this->assertNull($this->allocator->allocate($aircraft));
+        $this->assertNull(StandAssignment::find($aircraft->callsign));
+    }
+
+    private function createAircraft(
+        string $callsign,
+        string $arrivalAirport,
+        string $departureAirport
+    ): NetworkAircraft {
+        return NetworkAircraft::create(
+            [
+                'callsign' => $callsign,
+                'planned_aircraft' => 'B738',
+                'planned_destairport' => $arrivalAirport,
+                'planned_depairport' => $departureAirport,
+            ]
+        );
+    }
+}

--- a/tests/app/Services/AirlineServiceTest.php
+++ b/tests/app/Services/AirlineServiceTest.php
@@ -52,4 +52,29 @@ class AirlineServiceTest extends BaseFunctionalTestCase
     {
         $this->assertNull($this->service->getAirlineForAircraft(NetworkAircraft::create(['callsign' => '***'])));
     }
+
+    /**
+     * @dataProvider slugProvider
+     */
+    public function testItReturnsCallsignSlugs(string $callsign, string $expectedSlug)
+    {
+        $this->assertEquals(
+            $expectedSlug,
+            $this->service->getCallsignSlugForAircraft(NetworkAircraft::create(['callsign' => $callsign]))
+        );
+    }
+
+    public function slugProvider(): array
+    {
+        return [
+            'Unknown airline' => [
+                'X1X123',
+                'X1X123',
+            ],
+            'Known airline' => [
+                'BAW123AF',
+                '123AF',
+            ],
+        ];
+    }
 }

--- a/tests/app/Services/Stand/StandServiceTest.php
+++ b/tests/app/Services/Stand/StandServiceTest.php
@@ -3,6 +3,7 @@
 namespace App\Services\Stand;
 
 use App\Allocator\Stand\AirlineArrivalStandAllocator;
+use App\Allocator\Stand\AirlineCallsignSlugArrivalStandAllocator;
 use App\Allocator\Stand\AirlineDestinationArrivalStandAllocator;
 use App\Allocator\Stand\AirlineTerminalArrivalStandAllocator;
 use App\Allocator\Stand\CargoFlightPreferredArrivalStandAllocator;
@@ -687,6 +688,7 @@ class StandServiceTest extends BaseFunctionalTestCase
                 CallsignFlightplanReservedArrivalStandAllocator::class,
                 CargoFlightPreferredArrivalStandAllocator::class,
                 CargoFlightArrivalStandAllocator::class,
+                AirlineCallsignSlugArrivalStandAllocator::class,
                 AirlineDestinationArrivalStandAllocator::class,
                 AirlineArrivalStandAllocator::class,
                 AirlineTerminalArrivalStandAllocator::class,


### PR DESCRIPTION
- Add mechanism to allocate airline stands based on the callsign slug (the bit after the airline).
- Add stand allocations for Fly UK (UKV) based on slugs.

Resolve #857 