### PR TITLE
fix(squawks): prevent assignment of msfs default squawk

### DIFF
--- a/database/migrations/2022_05_11_213212_ban_msfs_default_squawk.php
+++ b/database/migrations/2022_05_11_213212_ban_msfs_default_squawk.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Models\Squawk\Reserved\NonAssignableSquawkCode;
+use Illuminate\Database\Migrations\Migration;
+
+class BanMsfsDefaultSquawk extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        NonAssignableSquawkCode::create(
+            [
+                'code' => '1234',
+                'description' => 'MSFS Default',
+            ]
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/tests/app/Services/SquawkServiceTest.php
+++ b/tests/app/Services/SquawkServiceTest.php
@@ -140,7 +140,7 @@ class SquawkServiceTest extends BaseFunctionalTestCase
         DB::table('network_aircraft')->insert(
             [
                 'callsign' => 'RYR999',
-                'transponder' => '1234',
+                'transponder' => '2345',
                 'transponder_last_updated_at' => Carbon::now()->subMinutes(3),
                 'updated_at' => Carbon::now(),
             ]
@@ -152,7 +152,7 @@ class SquawkServiceTest extends BaseFunctionalTestCase
             'squawk_assignments',
             [
                 'callsign' => 'RYR999',
-                'code' => '1234',
+                'code' => '2345',
                 'assignment_type' => 'NON_UKCP',
             ]
         );
@@ -164,7 +164,7 @@ class SquawkServiceTest extends BaseFunctionalTestCase
         DB::table('network_aircraft')->insert(
             [
                 'callsign' => 'RYR999',
-                'transponder' => '1234',
+                'transponder' => '2345',
                 'transponder_last_updated_at' => Carbon::now()->subMinutes(3),
                 'updated_at' => Carbon::now(),
             ]
@@ -177,7 +177,7 @@ class SquawkServiceTest extends BaseFunctionalTestCase
             'squawk_assignments',
             [
                 'callsign' => 'RYR999',
-                'code' => '1234',
+                'code' => '2345',
                 'assignment_type' => 'NON_UKCP',
             ]
         );
@@ -190,13 +190,13 @@ class SquawkServiceTest extends BaseFunctionalTestCase
             [
                 [
                     'callsign' => 'RYR999',
-                    'transponder' => '1234',
+                    'transponder' => '2345',
                     'transponder_last_updated_at' => Carbon::now()->subMinutes(3),
                     'updated_at' => Carbon::now(),
                 ],
                 [
                     'callsign' => 'WZZ888',
-                    'transponder' => '1234',
+                    'transponder' => '2345',
                     'transponder_last_updated_at' => Carbon::now()->subMinutes(3),
                     'updated_at' => Carbon::now(),
                 ],
@@ -209,7 +209,7 @@ class SquawkServiceTest extends BaseFunctionalTestCase
             'squawk_assignments',
             [
                 'callsign' => 'RYR999',
-                'code' => '1234',
+                'code' => '2345',
                 'assignment_type' => 'NON_UKCP',
             ]
         );


### PR DESCRIPTION
fix #923