### PR TITLE
feat: make api the root of the api

### DIFF
--- a/app/Http/Controllers/DependencyController.php
+++ b/app/Http/Controllers/DependencyController.php
@@ -44,7 +44,7 @@ class DependencyController extends BaseController
 
             return [
                 'key' => $dependency->key,
-                'uri' => sprintf('%s/dependency/%d', config('app.url'), $dependency->id),
+                'uri' => route('api.plugin.dependency.get', ['id' => $dependency->id]),
                 'local_file' => $dependency->local_file,
                 'updated_at' => $updatedAt->timestamp,
             ];

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -49,8 +49,7 @@ class RouteServiceProvider extends ServiceProvider
      */
     protected function mapWebRoutes()
     {
-        Route::prefix('web')
-            ->middleware('web')
+        Route::middleware('web')
             ->namespace($this->namespace)
             ->group(base_path('routes/web.php'));
     }
@@ -65,6 +64,7 @@ class RouteServiceProvider extends ServiceProvider
     protected function mapApiRoutes()
     {
         Route::namespace($this->namespace)
+            ->prefix('api')
             ->group(base_path('routes/api.php'));
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -7,9 +7,13 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Middleware\MiddlewareKeys;
 
 // Routes that the plugin user will use
-Route::middleware('api')->group(
+Route::middleware('api')
+    ->name('api.')
+    ->group(
     function () {
-        Route::middleware('plugin.user')->group(
+        Route::middleware('plugin.user')
+            ->name('plugin.')
+            ->group(
             function () {
                 Route::get(
                     '/authorise',
@@ -20,10 +24,18 @@ Route::middleware('api')->group(
                         'uses' => 'TeapotController@normalTeapots',
                     ]
                 );
+
                 // Dependencies
-                Route::get('dependency', 'DependencyController@getAllDependencies');
-                Route::get('dependency/{id}', 'DependencyController@getDependency')
-                    ->where('id', '[0-9]+');
+                Route::prefix('dependency')
+                    ->name('dependency.')
+                    ->group(function () {
+                        Route::get('{id}', 'DependencyController@getDependency')
+                            ->name('get')
+                            ->where('id', '[0-9]+');
+
+                        Route::get('', 'DependencyController@getAllDependencies')
+                            ->name('getall');
+                    });
 
                 // Departure releases
                 Route::post('departure/release/request', 'DepartureReleaseController@makeReleaseRequest');
@@ -263,7 +275,9 @@ Route::middleware('api')->group(
         );
 
         // Routes that can be hit by anybody at all, mostly login and informational routes
-        Route::middleware('public')->group(
+        Route::middleware('public')
+            ->name('public.')
+            ->group(
             function () {
                 Route::get(
                     '/',
@@ -361,9 +375,6 @@ Route::middleware('api')->group(
                     Route::get('latest', 'VersionController@getLatestVersion');
                     Route::get('{version:version}', 'VersionController@getVersion');
                 });
-
-                Route::get('dependency/{id}', 'DependencyController@getDependency')
-                    ->where('id', '[0-9]+');
             }
         );
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -10,11 +10,11 @@ use App\Http\Middleware\MiddlewareKeys;
 Route::middleware('api')
     ->name('api.')
     ->group(
-    function () {
+        function () {
         Route::middleware('plugin.user')
             ->name('plugin.')
             ->group(
-            function () {
+                function () {
                 Route::get(
                     '/authorise',
                     [
@@ -106,7 +106,7 @@ Route::middleware('api')
                         ->middleware(MiddlewareKeys::CONTROLLING_LIVE);
                 });
             }
-        );
+            );
 
 
         // Routes for user administration
@@ -278,7 +278,7 @@ Route::middleware('api')
         Route::middleware('public')
             ->name('public.')
             ->group(
-            function () {
+                function () {
                 Route::get(
                     '/',
                     function () {
@@ -376,6 +376,6 @@ Route::middleware('api')
                     Route::get('{version:version}', 'VersionController@getVersion');
                 });
             }
-        );
+            );
     }
-);
+    );

--- a/tests/BaseApiTestCase.php
+++ b/tests/BaseApiTestCase.php
@@ -137,7 +137,7 @@ abstract class BaseApiTestCase extends BaseFunctionalTestCase
      */
     private function makeApiRequest(string $method, string $route, array $headers = [], array $data = [])
     {
-        $route = 'api/' . $route;
+        $route = $this->addApiPrefixToRoute($route);
         $response = null;
         switch ($method) {
             case self::METHOD_GET:
@@ -173,5 +173,16 @@ abstract class BaseApiTestCase extends BaseFunctionalTestCase
         }
 
         return $response;
+    }
+
+    private function addApiPrefixToRoute(string $route): string
+    {
+        if (str_starts_with($route, 'api/')) {
+            return $route;
+        }
+
+        return str_starts_with($route, '/')
+            ? 'api' . $route
+            : 'api/' . $route;
     }
 }

--- a/tests/BaseApiTestCase.php
+++ b/tests/BaseApiTestCase.php
@@ -137,6 +137,7 @@ abstract class BaseApiTestCase extends BaseFunctionalTestCase
      */
     private function makeApiRequest(string $method, string $route, array $headers = [], array $data = [])
     {
+        $route = 'api/' . $route;
         $response = null;
         switch ($method) {
             case self::METHOD_GET:

--- a/tests/app/Console/Commands/DataAdminCreateTest.php
+++ b/tests/app/Console/Commands/DataAdminCreateTest.php
@@ -18,6 +18,6 @@ class DataAdminCreateTest extends BaseFunctionalTestCase
     {
         Artisan::call(self::ARTISAN_COMMAND);
         $token = explode(PHP_EOL, Artisan::output())[1];
-        $this->get('/dataadmin', ['Authorization' => 'Bearer ' . $token])->assertStatus(200);
+        $this->get('/api/dataadmin', ['Authorization' => 'Bearer ' . $token])->assertStatus(200);
     }
 }

--- a/tests/app/Console/Commands/UserAdminCreateTest.php
+++ b/tests/app/Console/Commands/UserAdminCreateTest.php
@@ -39,6 +39,6 @@ class UserAdminCreateTest extends BaseFunctionalTestCase
     {
         Artisan::call(self::ARTISAN_COMMAND);
         $token = explode(PHP_EOL, Artisan::output())[1];
-        $this->get('/useradmin', ['Authorization' => 'Bearer ' . $token])->assertStatus(200);
+        $this->get('/api/useradmin', ['Authorization' => 'Bearer ' . $token])->assertStatus(200);
     }
 }

--- a/tests/app/Http/Controllers/AuthenticationTest.php
+++ b/tests/app/Http/Controllers/AuthenticationTest.php
@@ -16,13 +16,13 @@ class AuthenticationTest extends BaseApiTestCase
 
     public function testLoginScreenCanBeRendered()
     {
-        $response = $this->get('web/login');
+        $response = $this->get('/login');
         $response->assertStatus(200);
     }
 
     public function testUsersCanAuthenticateUsingTheLoginScreen()
     {
-        $response = $this->post('web/login', [
+        $response = $this->post('/login', [
             'email' => Admin::find(1203533)->email,
             'password' => 'letmein',
         ]);
@@ -33,7 +33,7 @@ class AuthenticationTest extends BaseApiTestCase
 
     public function testUsersCannotAuthenticateWithInvalidPassword()
     {
-        $this->post('web/login', [
+        $this->post('/login', [
             'email' => Admin::find(1203533)->email,
             'password' => 'wrong-password',
         ]);

--- a/tests/app/Http/Controllers/DependencyControllerTest.php
+++ b/tests/app/Http/Controllers/DependencyControllerTest.php
@@ -60,7 +60,7 @@ class DependencyControllerTest extends BaseApiTestCase
         return [
             'key' => $key,
             'uri' => sprintf(
-                '%s/dependency/%d',
+                '%s/api/dependency/%d',
                 config(self::APP_URL_KEY),
                 Dependency::where('key', $key)->first()->id
             ),

--- a/tests/app/Http/Middleware/AuthenticateTest.php
+++ b/tests/app/Http/Middleware/AuthenticateTest.php
@@ -17,12 +17,12 @@ class AuthenticateTest extends BaseApiTestCase
 
     public function testItRejectsUsersWithNoKey()
     {
-        $this->json('GET', '/authorise')->assertStatus(401);
+        $this->json('GET', '/api/authorise')->assertStatus(401);
     }
 
     public function testItRejectsUsersWithInvalidKey()
     {
-        $this->json('GET', '/authorise', [], ['Authorization' => 'Bearer nope'])
+        $this->json('GET', '/api/authorise', [], ['Authorization' => 'Bearer nope'])
             ->assertStatus(401);
     }
 }

--- a/tests/app/Http/Middleware/LogAdminActionTest.php
+++ b/tests/app/Http/Middleware/LogAdminActionTest.php
@@ -45,7 +45,7 @@ class LogAdminActionTest extends BaseApiTestCase
             'admin_log',
             [
                 'user_id' => self::ACTIVE_USER_CID,
-                'request_uri' => "/admin/airfields/{$airfieldCode}/stands",
+                'request_uri' => "/api/admin/airfields/{$airfieldCode}/stands",
                 'request_body' => json_encode($standData),
             ]
         );

--- a/tests/app/Http/Middleware/UserIsBannedTest.php
+++ b/tests/app/Http/Middleware/UserIsBannedTest.php
@@ -23,7 +23,7 @@ class UserIsBannedTest extends BaseApiTestCase
 
         $this->json(
             'GET',
-            '/authorise',
+            '/api/authorise',
             [],
             ['Authorization' => 'Bearer ' . $token]
         )
@@ -40,7 +40,7 @@ class UserIsBannedTest extends BaseApiTestCase
         $token = $this->activeUser()->createToken('access', [AuthServiceProvider::SCOPE_USER])->accessToken;
         $this->json(
             'GET',
-            '/authorise',
+            '/api/authorise',
             [],
             ['Authorization' => 'Bearer ' . $token]
         )

--- a/tests/app/Http/Middleware/UserIsDisabledTest.php
+++ b/tests/app/Http/Middleware/UserIsDisabledTest.php
@@ -22,7 +22,7 @@ class UserIsDisabledTest extends BaseApiTestCase
         $token = $this->disabledUser()->createToken('access')->accessToken;
         $this->json(
             'GET',
-            '/authorise',
+            '/api/authorise',
             [],
             ['Authorization' => 'Bearer ' . $token]
         )
@@ -39,7 +39,7 @@ class UserIsDisabledTest extends BaseApiTestCase
         $token = $this->activeUser()->createToken('access', [AuthServiceProvider::SCOPE_USER])->accessToken;
         $this->json(
             'GET',
-            '/authorise',
+            '/api/authorise',
             [],
             ['Authorization' => 'Bearer ' . $token]
         )

--- a/tests/app/Services/UserServiceTest.php
+++ b/tests/app/Services/UserServiceTest.php
@@ -167,6 +167,6 @@ class UserServiceTest extends BaseFunctionalTestCase
 
     private function makeTestRequest(string $uri, string $token)
     {
-        $this->get($uri, ['Authorization' => 'Bearer ' . $token])->assertStatus(200);
+        $this->get('api' . $uri, ['Authorization' => 'Bearer ' . $token])->assertStatus(200);
     }
 }

--- a/tests/app/Services/UserTokenServiceTest.php
+++ b/tests/app/Services/UserTokenServiceTest.php
@@ -49,7 +49,7 @@ class UserTokenServiceTest extends BaseApiTestCase
     public function testItCreatesAUserToken()
     {
         $token = $this->service->create(1203533);
-        $this->get('/authorise', ['Authorization' => 'Bearer ' . $token])->assertStatus(200);
+        $this->get('api/authorise', ['Authorization' => 'Bearer ' . $token])->assertStatus(200);
     }
 
     public function testDeleteRemovesAToken()


### PR DESCRIPTION
Traditional Laravel APIs have `/api` as the root of the API routes. UKCP traditionally avoided this as originally we were a Lumen application with no "web" side. To make the project more relatable to other devs, this change makes all the api routes take the prefix `api`. Conversely, all the "web" routes no longer bear the prefix `/web`.

BREAKING CHANGE: This will change all the API routes so the plugin will need to be updated to account for this.