### PR TITLE
fix(stands) duplicate constraint failure on stand assignment#

### DIFF
--- a/app/Models/Vatsim/NetworkAircraft.php
+++ b/app/Models/Vatsim/NetworkAircraft.php
@@ -76,9 +76,6 @@ class NetworkAircraft extends Model
     public static function booted()
     {
         parent::booted();
-        static::addGlobalScope('active', function (Builder $builder) {
-            $builder->where('network_aircraft.updated_at', '>', Carbon::now()->subMinutes(self::TIME_OUT_MINUTES));
-        });
     }
 
     public function getSquawkAttribute(): string
@@ -160,6 +157,11 @@ class NetworkAircraft extends Model
     public function scopeTimedOut(Builder $builder): Builder
     {
         return $builder->where('network_aircraft.updated_at', '<', Carbon::now()->subMinutes(self::TIME_OUT_MINUTES));
+    }
+
+    public function scopeNotTimedOut(Builder $builder): Builder
+    {
+        return $builder->where('network_aircraft.updated_at', '>', Carbon::now()->subMinutes(self::TIME_OUT_MINUTES));
     }
 
     public function destinationAirfield(): BelongsTo

--- a/app/Services/NetworkAircraftService.php
+++ b/app/Services/NetworkAircraftService.php
@@ -128,8 +128,7 @@ class NetworkAircraftService
      */
     private function handleTimeouts(): void
     {
-        NetworkAircraft::withoutGlobalScope('active')
-            ->timedOut()
+        NetworkAircraft::timedOut()
             ->get()
             ->each(
                 function (NetworkAircraft $aircraft) {


### PR DESCRIPTION
Where aircraft had timed out, the departure stand assignment would not be found and thus caused duplicates to be assigned.