### PR TITLE
fix(admin): Ambiguous id on paired stand search

### DIFF
--- a/app/Filament/Resources/StandResource/RelationManagers/PairedStandsRelationManager.php
+++ b/app/Filament/Resources/StandResource/RelationManagers/PairedStandsRelationManager.php
@@ -35,10 +35,6 @@ class PairedStandsRelationManager extends RelationManager
 
         return $table
             ->columns([
-                Tables\Columns\TextColumn::make('id')
-                    ->label(self::translateTablePath('columns.id'))
-                    ->sortable()
-                    ->searchable(),
                 Tables\Columns\TextColumn::make('airfield.code')
                     ->label(self::translateTablePath('columns.airfield'))
                     ->sortable()


### PR DESCRIPTION
The id column (which doesn't add very much) on the paired stand table would cause an ambiguous reference in the SQL clause. So to make things work, remove that column.