### PR TITLE
feat: list squawk assignments in the plugin

### DIFF
--- a/app/Filament/Resources/SquawkAssignmentResource.php
+++ b/app/Filament/Resources/SquawkAssignmentResource.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\SquawkAssignmentResource\Pages;
+use App\Models\Squawk\SquawkAssignment;
+use Filament\Resources\Resource;
+use Filament\Resources\Table;
+use Filament\Tables;
+
+class SquawkAssignmentResource extends Resource
+{
+    use TranslatesStrings;
+
+    protected static ?string $model = SquawkAssignment::class;
+    protected static ?string $navigationIcon = 'heroicon-o-wifi';
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('callsign')
+                    ->label(self::translateTablePath('columns.callsign'))
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('code')
+                    ->label(self::translateTablePath('columns.code'))
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('assignment_type')
+                    ->label(self::translateTablePath('columns.type'))
+                    ->formatStateUsing(fn (string $state) => self::mapAssignmentTypeToString($state)),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListSquawkAssignments::route('/'),
+        ];
+    }
+
+    protected static function translationPathRoot(): string
+    {
+        return 'squawks.assignments';
+    }
+
+    protected static function mapAssignmentTypeToString(string $type): string
+    {
+        return match ($type) {
+            'NON_UKCP' => 'Not assigned by UKCP',
+            'AIRFIELD_PAIR' => 'Airfield pairing',
+            'CCAMS' => 'CCAMS',
+            'ORCAM' => 'ORCAM',
+            'UNIT_DISCRETE' => 'ATC unit discrete',
+            default => $type
+        };
+    }
+}

--- a/app/Filament/Resources/SquawkAssignmentResource/Pages/ListSquawkAssignments.php
+++ b/app/Filament/Resources/SquawkAssignmentResource/Pages/ListSquawkAssignments.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Filament\Resources\SquawkAssignmentResource\Pages;
+
+use App\Filament\Resources\Pages\LimitsTableRecordListingOptions;
+use App\Filament\Resources\SquawkAssignmentResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListSquawkAssignments extends ListRecords
+{
+    use LimitsTableRecordListingOptions;
+    protected static string $resource = SquawkAssignmentResource::class;
+}

--- a/config/filament-logger.php
+++ b/config/filament-logger.php
@@ -11,7 +11,7 @@ return [
         'logger' => \Z3d0X\FilamentLogger\Loggers\ResourceLogger::class,
         'color' => 'success',
         'exclude' => [
-            //App\Filament\Resources\UserResource::class,
+            \App\Filament\Resources\SquawkAssignmentResource::class
         ],
     ],
 

--- a/lang/en/squawks/table.php
+++ b/lang/en/squawks/table.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'assignments' => [
+        'columns' => [
+            'callsign' => 'Callsign',
+            'code' => 'Code',
+            'type' => 'Assignment Type',
+        ],
+    ],
+];

--- a/lang/en/table.php
+++ b/lang/en/table.php
@@ -12,5 +12,6 @@ return [
     'navaids' => require_once __DIR__ . '/navaids/table.php',
     'notifications' => require_once __DIR__ . '/notifications/table.php',
     'runways' => require_once __DIR__ . '/runways/table.php',
+    'squawks' => require_once __DIR__ . '/squawks/table.php',
     'srd' => require_once __DIR__ . '/srd/table.php',
 ];

--- a/tests/app/Filament/AccessCheckingHelpers/ChecksListingFilamentAccess.php
+++ b/tests/app/Filament/AccessCheckingHelpers/ChecksListingFilamentAccess.php
@@ -15,6 +15,7 @@ trait ChecksListingFilamentAccess
      */
     public function testItCanBeIndexed(?RoleKeys $role, bool $canIndex)
     {
+        $this->beforeListing();
         $user = User::factory()->create();
         $this->actingAs($user);
 
@@ -46,4 +47,12 @@ trait ChecksListingFilamentAccess
      * The text we expect to see on successful index load.
      */
     protected abstract function getIndexText(): array;
+
+    /**
+     * Can be overridden to provide a test fixture for the test if needed.
+     */
+    protected function beforeListing(): void
+    {
+
+    }
 }

--- a/tests/app/Filament/SquawkAssignmentResourceTest.php
+++ b/tests/app/Filament/SquawkAssignmentResourceTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Filament;
+
+use App\BaseFilamentTestCase;
+use App\Filament\AccessCheckingHelpers\ChecksListingFilamentAccess;
+use App\Filament\Resources\SquawkAssignmentResource;
+use App\Models\Squawk\SquawkAssignment;
+
+class SquawkAssignmentResourceTest extends BaseFilamentTestCase
+{
+    use ChecksListingFilamentAccess;
+
+    protected function getIndexText(): array
+    {
+        return ['Squawk Assignments', 'BAW123', '1234', 'Not assigned by UKCP'];
+    }
+
+    protected function resourceClass(): string
+    {
+        return SquawkAssignmentResource::class;
+    }
+
+    protected function beforeListing(): void
+    {
+        SquawkAssignment::create(
+            [
+                'callsign' => 'BAW123',
+                'code' => '1234',
+                'assignment_type' => 'NON_UKCP',
+            ]
+        );
+    }
+}


### PR DESCRIPTION
Allow users to view all the squawk assignments over at ukcp.vatsim.uk.