### PR TITLE
Squawk range label unit discrete

### DIFF
--- a/lang/en/squawks/form.php
+++ b/lang/en/squawks/form.php
@@ -65,10 +65,6 @@ return [
             'label' => 'Unit',
             'helper' => 'The unit that owns the range, e.g. EGKK, SCO, THAMES',
         ],
-        'rule_type' => [
-            'label' => 'Rule',
-            'helper' => 'The rule to apply to determine whether or not the range is relevant.',
-        ],
         'rule_flight_rules' => [
             'label' => 'Flight Rules',
             'helper' => 'Which flight rules this range applies to.',
@@ -100,10 +96,6 @@ return [
         'unit' => [
             'label' => 'Unit',
             'helper' => 'The unit that owns the range, e.g. EGKK, SCO, THAMES',
-        ],
-        'rule_type' => [
-            'label' => 'Rule',
-            'helper' => 'The rule to apply to determine whether or not the range is relevant.',
         ],
         'rule_flight_rules' => [
             'label' => 'Flight Rules',

--- a/lang/en/squawks/form.php
+++ b/lang/en/squawks/form.php
@@ -77,6 +77,10 @@ return [
             'label' => 'Position Type',
             'helper' => 'The position type that can use this squawk. Useful for specifying that squawks are reserved for tower positions etc.',
         ],
+        'rule_service' => [
+            'label' => 'Service Provision',
+            'helper' => 'The service/UKFIS provision this code applies to.',
+        ],
     ],
     'unit_discrete_guests' => [
         'primary' => [


### PR DESCRIPTION
Adds a missing translation string for the Unit Squawk Ranges admin panels.