### PR TITLE
feat: only allow one fir exit point per intention code

### DIFF
--- a/app/Filament/Resources/IntentionCodeResource.php
+++ b/app/Filament/Resources/IntentionCodeResource.php
@@ -55,9 +55,9 @@ class IntentionCodeResource extends Resource
                             ->label(self::translateFormPath('code_type.label'))
                             ->helperText(self::translateFormPath('code_type.helper')),
                         TextInput::make('single_code')
-                            ->required(fn(Closure $get) => $get('code_type') === 'single_code')
+                            ->required(fn (Closure $get) => $get('code_type') === 'single_code')
                             ->maxLength(2)
-                            ->hidden(fn(Closure $get) => $get('code_type') !== 'single_code')
+                            ->hidden(fn (Closure $get) => $get('code_type') !== 'single_code')
                             ->label(self::translateFormPath('single_code.label'))
                             ->helperText(self::translateFormPath('single_code.helper'))
                     ]),
@@ -79,14 +79,16 @@ class IntentionCodeResource extends Resource
                             ->minValue(1)
                             ->label(self::translateFormPath('position.label'))
                             ->helperText(self::translateFormPath('position.helper'))
-                            ->hidden(fn(Closure $get) => $get('order_type') !== 'at_position')
-                            ->required(fn(Closure $get) => $get('order_type') === 'at_position'),
+                            ->hidden(fn (Closure $get) => $get('order_type') !== 'at_position')
+                            ->required(fn (Closure $get) => $get('order_type') === 'at_position'),
                         Select::make('insert_position')
                             ->label(self::translateFormPath('before_after_position.label'))
                             ->helperText(self::translateFormPath('before_after_position.helper'))
-                            ->hidden(fn(Closure $get) => !in_array($get('order_type'), ['before', 'after']))
-                            ->required(fn(Closure $get) => in_array($get('order_type'), ['before', 'after']))
-                            ->options(fn() => IntentionCode::all()->mapWithKeys(fn(IntentionCode $code) => [$code->id => self::formatCodeColumn($code)]
+                            ->hidden(fn (Closure $get) => !in_array($get('order_type'), ['before', 'after']))
+                            ->required(fn (Closure $get) => in_array($get('order_type'), ['before', 'after']))
+                            ->options(
+                                fn () => IntentionCode::all()->mapWithKeys(
+                                fn (IntentionCode $code) => [$code->id => self::formatCodeColumn($code)]
                             )
                             ),
                     ]),
@@ -103,7 +105,7 @@ class IntentionCodeResource extends Resource
                 TextColumn::make('description')
                     ->label(self::translateTablePath('columns.description')),
                 TextColumn::make('code')
-                    ->formatStateUsing(fn(IntentionCode $record) => self::formatCodeColumn($record))
+                    ->formatStateUsing(fn (IntentionCode $record) => self::formatCodeColumn($record))
                     ->label(self::translateTablePath('columns.code')),
 
             ])
@@ -133,7 +135,7 @@ class IntentionCodeResource extends Resource
     }
 
     /**
-     * We only want to allow a single FIR exit point per intention code. This is necessary to make things simpler in 
+     * We only want to allow a single FIR exit point per intention code. This is necessary to make things simpler in
      * the plugin. TLDR:
      *
      * The plugin sends messages to its integrations, e.g. vStrips, these messages contain the FIR Exit Point that
@@ -185,7 +187,7 @@ class IntentionCodeResource extends Resource
                             ->helperText(self::translateFormPath('conditions.exit_point.helper'))
                             ->required()
                             ->searchable()
-                            ->options(fn() => SelectOptions::firExitPoints()),
+                            ->options(fn () => SelectOptions::firExitPoints()),
                     ]),
                 Block::make(ConditionType::MaximumCruisingLevel->value)
                     ->label(self::translateFormPath('conditions.maximum_cruising_level.menu_item'))
@@ -229,13 +231,13 @@ class IntentionCodeResource extends Resource
                     ]),
                 Block::make(ConditionType::Not->value)
                     ->label(self::translateFormPath('conditions.not.menu_item'))
-                    ->schema(fn() => [self::conditions(true)]),
+                    ->schema(fn () => [self::conditions(true)]),
                 Block::make(ConditionType::AnyOf->value)
                     ->label(self::translateFormPath('conditions.any_of.menu_item'))
-                    ->schema(fn() => [self::conditions(true)]),
+                    ->schema(fn () => [self::conditions(true)]),
                 Block::make(ConditionType::AllOf->value)
                     ->label(self::translateFormPath('conditions.all_of.menu_item'))
-                    ->schema(fn() => [self::conditions(true)])
+                    ->schema(fn () => [self::conditions(true)])
             ]);
     }
 

--- a/lang/en/intention/form.php
+++ b/lang/en/intention/form.php
@@ -34,7 +34,7 @@ return [
     'conditions' => [
         'conditions' => [
             'label' => 'Conditions',
-            'helper' => 'The conditions that must be met for this code to apply.',
+            'helper' => 'The conditions that must be met for this code to apply. Unless otherwise selected, these conditions are related by logical AND.',
         ],
         'arrival_airfields' => [
             'menu_item' => 'Arrival Airfields',
@@ -50,7 +50,7 @@ return [
         'exit_point' => [
             'menu_item' => 'FIR Exit Point',
             'label' => 'Exit Point',
-            'helper' => 'The place where the aircraft leaves the FIR. May be internal. In some cases, EGTT positions are shown intention codes based on where the aircraft leaves EGPX. Only one of these may be specified per intention code.',
+            'helper' => 'The place where the aircraft leaves the FIR. May be internal. In some cases, EGTT positions are shown intention codes based on where the aircraft leaves EGPX. Only one of these may be specified per intention code and must be specified at the highest level.',
         ],
         'maximum_cruising_level' => [
             'menu_item' => 'Maximum Cruising Altitude',

--- a/lang/en/intention/form.php
+++ b/lang/en/intention/form.php
@@ -50,7 +50,7 @@ return [
         'exit_point' => [
             'menu_item' => 'FIR Exit Point',
             'label' => 'Exit Point',
-            'helper' => 'The place where the aircraft leaves the FIR. May be internal. In some cases, EGTT positions are shown intention codes based on where the aircraft leaves EGPX.',
+            'helper' => 'The place where the aircraft leaves the FIR. May be internal. In some cases, EGTT positions are shown intention codes based on where the aircraft leaves EGPX. Only one of these may be specified per intention code.',
         ],
         'maximum_cruising_level' => [
             'menu_item' => 'Maximum Cruising Altitude',


### PR DESCRIPTION
Prevents an intention code from having more than 1 FIR exit point as a condition. This is necessary to make things simpler on the plugin-side with regards to sending integration messages to vStrips etc.