### PR TITLE
Create network aircraft for stand assignments

### DIFF
--- a/app/Services/Stand/StandAssignmentsService.php
+++ b/app/Services/Stand/StandAssignmentsService.php
@@ -66,7 +66,7 @@ class StandAssignmentsService
             });
 
             // Create new stand assignment
-            NetworkAircraftService::createOrUpdateNetworkAircraft($callsign);
+            NetworkAircraftService::createPlaceholderAircraft($callsign);
             $assignment = StandAssignment::updateOrCreate(
                 ['callsign' => $callsign],
                 [

--- a/app/Services/Stand/StandAssignmentsService.php
+++ b/app/Services/Stand/StandAssignmentsService.php
@@ -8,6 +8,7 @@ use App\Exceptions\Stand\StandNotFoundException;
 use App\Models\Stand\Stand;
 use App\Models\Stand\StandAssignment;
 use App\Models\Vatsim\NetworkAircraft;
+use App\Services\NetworkAircraftService;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\DB;
 
@@ -65,6 +66,7 @@ class StandAssignmentsService
             });
 
             // Create new stand assignment
+            NetworkAircraftService::createOrUpdateNetworkAircraft($callsign);
             $assignment = StandAssignment::updateOrCreate(
                 ['callsign' => $callsign],
                 [


### PR DESCRIPTION
Fixes an error with integrity constraints when users assign the stand before the API has a chance to see the aircraft in the network feed.