### PR TITLE
Airline admin

### DIFF
--- a/app/Filament/Resources/AirlineResource.php
+++ b/app/Filament/Resources/AirlineResource.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources;
 
 use App\Filament\Helpers\SelectOptions;
 use App\Filament\Resources\AirlineResource\Pages;
+use App\Filament\Resources\AirlineResource\RelationManagers\StandsRelationManager;
 use App\Filament\Resources\AirlineResource\RelationManagers\TerminalsRelationManager;
 use App\Models\Airline\Airline;
 use Filament\Forms\Components\Fieldset;
@@ -95,6 +96,7 @@ class AirlineResource extends Resource
     {
         return [
             TerminalsRelationManager::class,
+            StandsRelationManager::class,
         ];
     }
 

--- a/app/Filament/Resources/AirlineResource.php
+++ b/app/Filament/Resources/AirlineResource.php
@@ -2,11 +2,16 @@
 
 namespace App\Filament\Resources;
 
+use App\Filament\Helpers\SelectOptions;
 use App\Filament\Resources\AirlineResource\Pages;
 use App\Models\Airline\Airline;
+use Filament\Forms\Components\Fieldset;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 use Filament\Resources\Form;
+use Filament\Resources\Pages\CreateRecord;
+use Filament\Resources\Pages\Page;
 use Filament\Resources\Resource;
 use Filament\Resources\Table;
 use Filament\Tables\Actions\DeleteAction;
@@ -41,10 +46,24 @@ class AirlineResource extends Resource
                     ->maxLength(255)
                     ->label(self::translateFormPath('callsign.label'))
                     ->helperText(self::translateFormPath('callsign.helper')),
+
                 Toggle::make('is_cargo')
                     ->label(self::translateFormPath('is_cargo.label'))
                     ->helperText(self::translateFormPath('is_cargo.helper'))
                     ->required(),
+                Fieldset::make(self::translateFormPath('fieldset_creation_options.label'))
+                    ->schema(
+                        [
+                            Select::make('copy_stand_assignments')
+                                ->options(SelectOptions::airlines())
+                                ->searchable()
+                                ->label(self::translateFormPath('copy_stand_assignments.label'))
+                                ->helperText(self::translateFormPath('copy_stand_assignments.helper'))
+                        ]
+                    )
+                    ->hidden(fn (Page $livewire) => !$livewire instanceof CreateRecord)
+                    ->disabled(fn (Page $livewire) => !$livewire instanceof CreateRecord)
+                    ->dehydrated(fn (Page $livewire) => $livewire instanceof CreateRecord),
             ]);
     }
 

--- a/app/Filament/Resources/AirlineResource.php
+++ b/app/Filament/Resources/AirlineResource.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\AirlineResource\Pages;
+use App\Models\Airline\Airline;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Resources\Form;
+use Filament\Resources\Resource;
+use Filament\Resources\Table;
+use Filament\Tables\Actions\DeleteAction;
+use Filament\Tables\Actions\EditAction;
+use Filament\Tables\Actions\ViewAction;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+
+class AirlineResource extends Resource
+{
+    use TranslatesStrings;
+
+    public static ?string $navigationIcon = 'heroicon-o-paper-airplane';
+    protected static ?string $recordTitleAttribute = 'icao_code';
+    protected static ?string $navigationGroup = 'Airline';
+    protected static ?string $model = Airline::class;
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                TextInput::make('icao_code')
+                    ->required()
+                    ->maxLength(255)
+                    ->label(self::translateFormPath('icao_code.label')),
+                TextInput::make('name')
+                    ->required()
+                    ->maxLength(255)
+                    ->label(self::translateFormPath('name.label')),
+                TextInput::make('callsign')
+                    ->required()
+                    ->maxLength(255)
+                    ->label(self::translateFormPath('callsign.label'))
+                    ->helperText(self::translateFormPath('callsign.helper')),
+                Toggle::make('is_cargo')
+                    ->label(self::translateFormPath('is_cargo.label'))
+                    ->helperText(self::translateFormPath('is_cargo.helper'))
+                    ->required(),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('icao_code')
+                    ->label(self::translateTablePath('columns.icao_code'))
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('name')
+                    ->label(self::translateTablePath('columns.name')),
+                TextColumn::make('callsign')
+                    ->label(self::translateTablePath('columns.callsign')),
+                IconColumn::make('is_cargo')
+                    ->label(self::translateTablePath('columns.is_cargo'))
+                    ->boolean(),
+            ])
+            ->actions([
+                ViewAction::make(),
+                EditAction::make(),
+                DeleteAction::make(),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListAirlines::route('/'),
+            'create' => Pages\CreateAirline::route('/create'),
+            'view' => Pages\ViewAirline::route('/{record}'),
+            'edit' => Pages\EditAirline::route('/{record}/edit'),
+        ];
+    }
+
+    protected static function translationPathRoot(): string
+    {
+        return 'airlines';
+    }
+}

--- a/app/Filament/Resources/AirlineResource.php
+++ b/app/Filament/Resources/AirlineResource.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources;
 
 use App\Filament\Helpers\SelectOptions;
 use App\Filament\Resources\AirlineResource\Pages;
+use App\Filament\Resources\AirlineResource\RelationManagers\TerminalsRelationManager;
 use App\Models\Airline\Airline;
 use Filament\Forms\Components\Fieldset;
 use Filament\Forms\Components\Select;
@@ -93,7 +94,7 @@ class AirlineResource extends Resource
     public static function getRelations(): array
     {
         return [
-            //
+            TerminalsRelationManager::class,
         ];
     }
 

--- a/app/Filament/Resources/AirlineResource/Pages/CreateAirline.php
+++ b/app/Filament/Resources/AirlineResource/Pages/CreateAirline.php
@@ -3,10 +3,76 @@
 namespace App\Filament\Resources\AirlineResource\Pages;
 
 use App\Filament\Resources\AirlineResource;
+use App\Models\Airfield\Terminal;
+use App\Models\Airline\Airline;
+use App\Models\Stand\Stand;
 use Filament\Resources\Pages\CreateRecord;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Support\Facades\DB;
 
 class CreateAirline extends CreateRecord
 {
     public static string $resource = AirlineResource::class;
-}
 
+    protected function handleRecordCreation(array $data): Model
+    {
+        return DB::transaction(function () use ($data): Airline {
+            return tap(
+                static::getModel()::create($data),
+                function (Airline $newAirline) use ($data): void {
+                    if (!$data['copy_stand_assignments']) {
+                        return;
+                    }
+
+                    // They've selected an airline to copy assignments from, grab the airline
+                    $copyFromAirline = Airline::with('stands', 'terminals')
+                        ->findOrFail($data['copy_stand_assignments']);
+
+                    // Sync the terminal assignments
+                    if ($copyFromAirline->terminals->isNotEmpty()) {
+                        $newAirline->terminals()->sync(
+                            $copyFromAirline->terminals->mapWithKeys(
+                                fn (Terminal $terminal) => [
+                                    $terminal->id => $this->getCopyablePivotAttributes('terminal_id', $terminal->pivot)
+                                ]
+                            )
+                        );
+                    }
+
+                    // Sync the stand assignments
+                    if ($copyFromAirline->stands->isNotEmpty()) {
+                        $newAirline->stands()->sync(
+                            $copyFromAirline->stands->mapWithKeys(
+                                fn (Stand $stand) => [
+                                    $stand->id => $this->getCopyablePivotAttributes('stand_id', $stand->pivot)
+                                ]
+                            )
+                        );
+                    }
+                }
+            );
+        });
+    }
+
+    private function getCopyablePivotAttributes(string $localModelColumn, Pivot $pivot): array
+    {
+        $keysToRemove = array_merge(
+            [
+                'id',
+                'created_at',
+                'updated_at',
+                'airline_id',
+            ],
+            [
+                $localModelColumn
+            ]
+        );
+
+        return array_filter(
+            $pivot->getAttributes(),
+            fn (mixed $value, string $key) => !in_array($key, $keysToRemove),
+            ARRAY_FILTER_USE_BOTH
+        );
+    }
+}

--- a/app/Filament/Resources/AirlineResource/Pages/CreateAirline.php
+++ b/app/Filament/Resources/AirlineResource/Pages/CreateAirline.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Filament\Resources\AirlineResource\Pages;
+
+use App\Filament\Resources\AirlineResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateAirline extends CreateRecord
+{
+    public static string $resource = AirlineResource::class;
+}
+

--- a/app/Filament/Resources/AirlineResource/Pages/EditAirline.php
+++ b/app/Filament/Resources/AirlineResource/Pages/EditAirline.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Filament\Resources\AirlineResource\Pages;
+
+use App\Filament\Resources\AirlineResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditAirline extends EditRecord
+{
+    public static string $resource = AirlineResource::class;
+}
+

--- a/app/Filament/Resources/AirlineResource/Pages/EditAirline.php
+++ b/app/Filament/Resources/AirlineResource/Pages/EditAirline.php
@@ -9,4 +9,3 @@ class EditAirline extends EditRecord
 {
     public static string $resource = AirlineResource::class;
 }
-

--- a/app/Filament/Resources/AirlineResource/Pages/ListAirlines.php
+++ b/app/Filament/Resources/AirlineResource/Pages/ListAirlines.php
@@ -20,4 +20,3 @@ class ListAirlines extends ListRecords
         ];
     }
 }
-

--- a/app/Filament/Resources/AirlineResource/Pages/ListAirlines.php
+++ b/app/Filament/Resources/AirlineResource/Pages/ListAirlines.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Filament\Resources\AirlineResource\Pages;
+
+use App\Filament\Resources\AirlineResource;
+use App\Filament\Resources\Pages\LimitsTableRecordListingOptions;
+use Filament\Pages\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListAirlines extends ListRecords
+{
+    use LimitsTableRecordListingOptions;
+
+    public static string $resource = AirlineResource::class;
+
+    protected function getActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}
+

--- a/app/Filament/Resources/AirlineResource/Pages/ViewAirline.php
+++ b/app/Filament/Resources/AirlineResource/Pages/ViewAirline.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\AirlineResource\Pages;
+
+use App\Filament\Resources\AirlineResource;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewAirline extends ViewRecord
+{
+    public static string $resource = AirlineResource::class;
+}

--- a/app/Filament/Resources/AirlineResource/RelationManagers/StandsRelationManager.php
+++ b/app/Filament/Resources/AirlineResource/RelationManagers/StandsRelationManager.php
@@ -57,7 +57,9 @@ class StandsRelationManager extends RelationManager
             ->headerActions([
                 Tables\Actions\AttachAction::make('pair-stand')
                     ->form(fn (Tables\Actions\AttachAction $action): array => [
-                        $action->getRecordSelect()
+                        $action
+                            ->recordTitle(fn (Stand $record):string => $record->airfieldIdentifier)
+                            ->getRecordSelect()
                             ->label(self::translateFormPath('icao.label'))
                             ->required(),
                         TextInput::make('destination')

--- a/app/Filament/Resources/AirlineResource/RelationManagers/StandsRelationManager.php
+++ b/app/Filament/Resources/AirlineResource/RelationManagers/StandsRelationManager.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Filament\Resources\AirlineResource\RelationManagers;
+
+use App\Filament\Resources\Pages\LimitsTableRecordListingOptions;
+use App\Filament\Resources\TranslatesStrings;
+use App\Models\Stand\Stand;
+use Carbon\Carbon;
+use Closure;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\TimePicker;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Resources\Table;
+use Filament\Tables;
+use Filament\Tables\Actions\DetachAction;
+use Illuminate\Support\Facades\DB;
+
+class StandsRelationManager extends RelationManager
+{
+    use LimitsTableRecordListingOptions;
+    use TranslatesStrings;
+
+    private const DEFAULT_COLUMN_VALUE = '--';
+    protected bool $allowsDuplicates = true;
+    protected static string $relationship = 'stands';
+    protected static ?string $inverseRelationship = 'airlines';
+    protected static ?string $recordTitleAttribute = 'identifier';
+
+    protected function getTableDescription(): ?string
+    {
+        return self::translateTablePath('description');
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('stand_id')
+                    ->formatStateUsing(fn (Stand $record) => $record->airfieldIdentifier)
+                    ->label(self::translateTablePath('columns.terminal'))
+                    ->sortable()
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('destination')
+                    ->label(self::translateTablePath('columns.destination'))
+                    ->default(self::DEFAULT_COLUMN_VALUE)
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('callsign_slug')
+                    ->default(self::DEFAULT_COLUMN_VALUE)
+                    ->label(self::translateTablePath('columns.callsign')),
+                Tables\Columns\TextColumn::make('priority')
+                    ->default(self::DEFAULT_COLUMN_VALUE)
+                    ->label(self::translateTablePath('columns.priority')),
+                Tables\Columns\TextColumn::make('not_before')
+                    ->label(self::translateTablePath('columns.not_before'))
+                    ->date('H:i'),
+            ])
+            ->headerActions([
+                Tables\Actions\AttachAction::make('pair-stand')
+                    ->form(fn (Tables\Actions\AttachAction $action): array => [
+                        $action->getRecordSelect()
+                            ->label(self::translateFormPath('icao.label'))
+                            ->required(),
+                        TextInput::make('destination')
+                            ->label(self::translateFormPath('destination.label'))
+                            ->helperText(self::translateFormPath('destination.helper'))
+                            ->maxLength(4),
+                        TextInput::make('callsign_slug')
+                            ->label(self::translateFormPath('callsign.label'))
+                            ->helperText(self::translateFormPath('callsign.helper'))
+                            ->maxLength(4),
+                        TextInput::make('priority')
+                            ->label(self::translateFormPath('priority.label'))
+                            ->helperText(self::translateFormPath('priority.helper'))
+                            ->default(100)
+                            ->numeric()
+                            ->minValue(1)
+                            ->maxValue(9999)
+                            ->required(),
+                        TimePicker::make('not_before')
+                            ->label(self::translateFormPath('not_before.label'))
+                            ->helperText(self::translateFormPath('not_before.helper'))
+                            ->displayFormat('H:i')
+                            ->afterStateUpdated(function (Closure $get, Closure $set) {
+                                if ($get('not_before') !== null) {
+                                    $set(
+                                        'not_before',
+                                        Carbon::parse($get('not_before'))->startOfMinute()->toDateTimeString()
+                                    );
+                                }
+                            }),
+                    ])
+            ])
+            ->actions([
+                DetachAction::make('unpair-stand')
+                    ->label(self::translateFormPath('remove.label'))
+                    ->using(function (DetachAction $action) {
+                        DB::table('airline_stand')
+                            ->where('id', $action->getRecord()->pivot_id)
+                            ->delete();
+                    })
+            ]);
+    }
+
+    protected static function translationPathRoot(): string
+    {
+        return 'airlines.stands';
+    }
+}

--- a/app/Filament/Resources/AirlineResource/RelationManagers/TerminalsRelationManager.php
+++ b/app/Filament/Resources/AirlineResource/RelationManagers/TerminalsRelationManager.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Filament\Resources\AirlineResource\RelationManagers;
+
+use App\Filament\Resources\Pages\LimitsTableRecordListingOptions;
+use App\Filament\Resources\TranslatesStrings;
+use App\Models\Airfield\Terminal;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Resources\Table;
+use Filament\Tables;
+use Filament\Tables\Actions\DetachAction;
+use Illuminate\Support\Facades\DB;
+
+class TerminalsRelationManager extends RelationManager
+{
+    use LimitsTableRecordListingOptions;
+    use TranslatesStrings;
+
+    private const DEFAULT_COLUMN_VALUE = '--';
+    protected bool $allowsDuplicates = true;
+    protected static string $relationship = 'terminals';
+    protected static ?string $inverseRelationship = 'airlines';
+    protected static ?string $recordTitleAttribute = 'description';
+
+    protected function getTableDescription(): ?string
+    {
+        return self::translateTablePath('description');
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('terminal')
+                    ->formatStateUsing(fn (Terminal $record) => sprintf('%s / %s', $record->airfield->code, $record->description))
+                    ->label(self::translateTablePath('columns.terminal'))
+                    ->sortable()
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('destination')
+                    ->label(self::translateTablePath('columns.destination'))
+                    ->default(self::DEFAULT_COLUMN_VALUE)
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('callsign_slug')
+                    ->default(self::DEFAULT_COLUMN_VALUE)
+                    ->label(self::translateTablePath('columns.callsign')),
+                Tables\Columns\TextColumn::make('priority')
+                    ->default(self::DEFAULT_COLUMN_VALUE)
+                    ->label(self::translateTablePath('columns.priority'))
+            ])
+            ->headerActions([
+                Tables\Actions\AttachAction::make('pair-terminal')
+                    ->form(fn (Tables\Actions\AttachAction $action): array => [
+                        $action->getRecordSelect()
+                            ->label(self::translateFormPath('icao.label'))
+                            ->required(),
+                        TextInput::make('destination')
+                            ->label(self::translateFormPath('destination.label'))
+                            ->helperText(self::translateFormPath('destination.helper'))
+                            ->maxLength(4),
+                        TextInput::make('callsign_slug')
+                            ->label(self::translateFormPath('callsign.label'))
+                            ->helperText(self::translateFormPath('callsign.helper'))
+                            ->maxLength(4),
+                        TextInput::make('priority')
+                            ->label(self::translateFormPath('priority.label'))
+                            ->helperText(self::translateFormPath('priority.helper'))
+                            ->default(100)
+                            ->numeric()
+                            ->minValue(1)
+                            ->maxValue(9999)
+                            ->required(),
+                    ])
+            ])
+            ->actions([
+                DetachAction::make('unpair-terminal')
+                    ->label(self::translateFormPath('remove.label'))
+                    ->using(function (DetachAction $action) {
+                        DB::table('airline_terminal')
+                            ->where('id', $action->getRecord()->pivot_id)
+                            ->delete();
+                    })
+            ]);
+    }
+
+    protected static function translationPathRoot(): string
+    {
+        return 'airlines.terminals';
+    }
+}

--- a/app/Filament/Resources/AirlineResource/RelationManagers/TerminalsRelationManager.php
+++ b/app/Filament/Resources/AirlineResource/RelationManagers/TerminalsRelationManager.php
@@ -51,7 +51,9 @@ class TerminalsRelationManager extends RelationManager
             ->headerActions([
                 Tables\Actions\AttachAction::make('pair-terminal')
                     ->form(fn (Tables\Actions\AttachAction $action): array => [
-                        $action->getRecordSelect()
+                        $action
+                            ->recordTitle(fn (Terminal $record):string => $record->airfieldDescription)
+                            ->getRecordSelect()
                             ->label(self::translateFormPath('icao.label'))
                             ->required(),
                         TextInput::make('destination')

--- a/app/Filament/Resources/AirlineResource/RelationManagers/TerminalsRelationManager.php
+++ b/app/Filament/Resources/AirlineResource/RelationManagers/TerminalsRelationManager.php
@@ -33,7 +33,9 @@ class TerminalsRelationManager extends RelationManager
         return $table
             ->columns([
                 Tables\Columns\TextColumn::make('terminal')
-                    ->formatStateUsing(fn (Terminal $record) => sprintf('%s / %s', $record->airfield->code, $record->description))
+                    ->formatStateUsing(
+                        fn (Terminal $record) => sprintf('%s / %s', $record->airfield->code, $record->description)
+                    )
                     ->label(self::translateTablePath('columns.terminal'))
                     ->sortable()
                     ->searchable(),

--- a/app/Models/Airfield/Terminal.php
+++ b/app/Models/Airfield/Terminal.php
@@ -41,4 +41,9 @@ class Terminal extends Model
     {
         return $this->hasMany(Stand::class);
     }
+
+    public function getAirfieldDescriptionAttribute(): string
+    {
+        return sprintf('%s / %s', $this->airfield->code, $this->description);
+    }
 }

--- a/app/Models/Airline/Airline.php
+++ b/app/Models/Airline/Airline.php
@@ -22,7 +22,9 @@ class Airline extends Model
 
     public function terminals(): BelongsToMany
     {
-        return $this->belongsToMany(Terminal::class)->withTimestamps();
+        return $this->belongsToMany(Terminal::class)
+            ->withPivot('id', 'destination', 'priority', 'callsign_slug')
+            ->withTimestamps();
     }
 
     public function stands(): BelongsToMany

--- a/app/Models/Stand/Stand.php
+++ b/app/Models/Stand/Stand.php
@@ -307,6 +307,6 @@ class Stand extends Model
 
     public function getAirfieldIdentifierAttribute(): string
     {
-        return sprintf('%s - %s', $this->airfield->code, $this->identifier);
+        return sprintf('%s / %s', $this->airfield->code, $this->identifier);
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -73,6 +73,7 @@ class AppServiceProvider extends ServiceProvider
             Filament::registerTheme(mix('css/vatukfilament.css'));
             Filament::registerNavigationGroups(
                 [
+                    'Airline',
                     'Airfield',
                     'Controller',
                     'Enroute',

--- a/lang/en/airlines/form.php
+++ b/lang/en/airlines/form.php
@@ -21,5 +21,26 @@ return [
     'copy_stand_assignments' => [
         'label' => 'Copy Stand Assignments',
         'helper' => 'If selected, will copy any existing stand and terminal assignments from the specified airline when creating.'
-    ]
+    ],
+    'terminals' => [
+        'terminal' => [
+            'label' => 'Terminal',
+        ],
+        'destination' => [
+            'label' => 'Destination',
+            'helper' => 'The destination used for this allocation. Can be partial matches, for example, "EGJ".'
+        ],
+        'callsign' => [
+            'label' => 'Callsign Slug',
+            'helper' => 'The part of the callsign after the ICAO code for this allocation. Can be partial matches.'
+        ],
+        'priority' => [
+            'label' => 'Allocation Priority',
+            'helper' => 'Priority for allocating this terminal, lower value is higher priority. ' .
+                'Considered before general allocation priority. Minimum 1, maximum 9999.'
+        ],
+        'remove' => [
+            'label' => 'Remove',
+        ],
+    ],
 ];

--- a/lang/en/airlines/form.php
+++ b/lang/en/airlines/form.php
@@ -15,4 +15,11 @@ return [
         'label' => 'Is Cargo',
         'helper' => 'Airlines designated as cargo will always be assigned cargo stands in lieu of specific airline assignments',
     ],
+    'fieldset_creation_options' => [
+        'label' => 'Creation Options',
+    ],
+    'copy_stand_assignments' => [
+        'label' => 'Copy Stand Assignments',
+        'helper' => 'If selected, will copy any existing stand and terminal assignments from the specified airline when creating.'
+    ]
 ];

--- a/lang/en/airlines/form.php
+++ b/lang/en/airlines/form.php
@@ -1,0 +1,18 @@
+<?php
+
+return [
+    'icao_code' => [
+        'label' => 'ICAO Code',
+    ],
+    'name' => [
+        'label' => 'Name',
+    ],
+    'callsign' => [
+        'label' => 'Callsign',
+        'helper' => 'The RTF callsign for the airline',
+    ],
+    'is_cargo' => [
+        'label' => 'Is Cargo',
+        'helper' => 'Airlines designated as cargo will always be assigned cargo stands in lieu of specific airline assignments',
+    ],
+];

--- a/lang/en/airlines/form.php
+++ b/lang/en/airlines/form.php
@@ -43,4 +43,29 @@ return [
             'label' => 'Remove',
         ],
     ],
+    'stands' => [
+        'icao' => [
+            'label' => 'ICAO Code',
+        ],
+        'destination' => [
+            'label' => 'Destination',
+            'helper' => 'The destination used for this allocation. Can be partial matches, for example, "EGJ".'
+        ],
+        'callsign' => [
+            'label' => 'Callsign Slug',
+            'helper' => 'The part of the callsign after the ICAO code for this allocation. Can be partial matches.'
+        ],
+        'priority' => [
+            'label' => 'Allocation Priority',
+            'helper' => 'Priority for allocating this stand, lower value is higher priority. ' .
+                'Considered before general allocation priority. Minimum 1, maximum 9999.'
+        ],
+        'not_before' => [
+            'label' => 'Do not allocate before (UTC)',
+            'helper' => 'Will not allocate this stand automatically for arrivals before this time.'
+        ],
+        'remove' => [
+            'label' => 'Remove',
+        ],
+    ],
 ];

--- a/lang/en/airlines/table.php
+++ b/lang/en/airlines/table.php
@@ -7,4 +7,15 @@ return [
         'callsign' => 'RTF Callsign',
         'is_cargo' => 'Is Cargo',
     ],
+    'terminals' => [
+        'description' => 'Airlines can be assigned to specific terminals based on various parameters. The allocation ' .
+            'tries to match by Callsign Slug, then by Destination (always taking priority into account), then any ' .
+            'stand for that airline (preferring ones without specific callsigns or destinations).',
+        'columns' => [
+            'terminal' => 'Terminal',
+            'destination' => 'Origin',
+            'callsign' => 'Callsign Slug',
+            'priority' => 'Allocation Priority',
+        ],
+    ],
 ];

--- a/lang/en/airlines/table.php
+++ b/lang/en/airlines/table.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'columns' => [
+        'icao_code' => 'ICAO Code',
+        'name' => 'Name',
+        'callsign' => 'RTF Callsign',
+        'is_cargo' => 'Is Cargo',
+    ],
+];

--- a/lang/en/airlines/table.php
+++ b/lang/en/airlines/table.php
@@ -18,4 +18,16 @@ return [
             'priority' => 'Allocation Priority',
         ],
     ],
+    'stands' => [
+        'description' => 'Airlines can be assigned to specific stands based on various parameters. The allocation ' .
+            'tries to match by Callsign Slug, then by Destination (always taking priority into account), then any ' .
+            'stand for that airline (preferring ones without specific callsigns or destinations).',
+        'columns' => [
+            'icao' => 'ICAO Code',
+            'destination' => 'Origin',
+            'callsign' => 'Callsign Slug',
+            'priority' => 'Allocation Priority',
+            'not_before' => 'Not Before [UTC]',
+        ],
+    ],
 ];

--- a/lang/en/form.php
+++ b/lang/en/form.php
@@ -2,6 +2,7 @@
 
 return [
     'airfields' => require_once __DIR__ . '/airfields/form.php',
+    'airlines' => require_once __DIR__ . '/airlines/form.php',
     'fir_exit_points' => require_once __DIR__ . '/fir_exit_points/form.php',
     'intention' => require_once __DIR__ . '/intention/form.php',
     'stands' => require_once __DIR__ . '/stands/form.php',

--- a/lang/en/table.php
+++ b/lang/en/table.php
@@ -2,6 +2,7 @@
 
 return [
     'airfields' => require_once __DIR__ . '/airfields/table.php',
+    'airlines' => require_once __DIR__ . '/airlines/table.php',
     'dependencies' => require_once __DIR__ . '/dependencies/table.php',
     'fir_exit_points' => require_once __DIR__ . '/fir_exit_points/table.php',
     'intention' => require_once __DIR__ . '/intention/table.php',

--- a/tests/app/Filament/AirlineResourceTest.php
+++ b/tests/app/Filament/AirlineResourceTest.php
@@ -1,0 +1,406 @@
+<?php
+
+namespace App\Filament;
+
+use App\BaseFilamentTestCase;
+use App\Filament\Resources\AirlineResource;
+use App\Filament\Resources\AirlineResource\Pages\CreateAirline;
+use App\Filament\Resources\AirlineResource\Pages\EditAirline;
+use App\Filament\Resources\AirlineResource\Pages\ListAirlines;
+use App\Filament\Resources\AirlineResource\Pages\ViewAirline;
+use App\Models\Airline\Airline;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+
+class AirlineResourceTest extends BaseFilamentTestCase
+{
+    use ChecksOperationsContributorActionVisibility;
+    use ChecksOperationsContributorAccess;
+
+    public function testItLoadsDataForView()
+    {
+        Livewire::test(ViewAirline::class, ['record' => 1])
+            ->assertSet('data.icao_code', 'BAW')
+            ->assertSet('data.name', 'British Airways')
+            ->assertSet('data.callsign', 'SPEEDBIRD')
+            ->assertSet('data.is_cargo', false);
+    }
+
+    public function testItCreatesAnAirline()
+    {
+        Livewire::test(CreateAirline::class)
+            ->set('data.icao_code', 'EZY')
+            ->set('data.name', 'EasyJet')
+            ->set('data.callsign', 'EASY')
+            ->set('data.is_cargo', false)
+            ->call('create')
+            ->assertHasNoErrors();
+
+        $this->assertDatabaseHas(
+            'airlines',
+            [
+                'icao_code' => 'EZY',
+                'name' => 'EasyJet',
+                'callsign' => 'EASY',
+                'is_cargo' => false,
+            ]
+        );
+    }
+
+    public function testItCreatesACargoAirline()
+    {
+        Livewire::test(CreateAirline::class)
+            ->set('data.icao_code', 'EZY')
+            ->set('data.name', 'EasyJet Cargo')
+            ->set('data.callsign', 'EASY')
+            ->set('data.is_cargo', true)
+            ->call('create')
+            ->assertHasNoErrors();
+
+        $this->assertDatabaseHas(
+            'airlines',
+            [
+                'icao_code' => 'EZY',
+                'name' => 'EasyJet Cargo',
+                'callsign' => 'EASY',
+                'is_cargo' => true,
+            ]
+        );
+    }
+
+    public function testItDoesntCreateAnAirlineNoIcaoCode()
+    {
+        Livewire::test(CreateAirline::class)
+            ->set('data.name', 'EasyJet')
+            ->set('data.callsign', 'EASY')
+            ->set('data.is_cargo', false)
+            ->call('create')
+            ->assertHasErrors(['data.icao_code']);
+    }
+
+    public function testItDoesntCreateAnAirlineIcaoCodeEmpty()
+    {
+        Livewire::test(CreateAirline::class)
+            ->set('data.icao_code', '')
+            ->set('data.name', 'EasyJet')
+            ->set('data.callsign', 'EASY')
+            ->set('data.is_cargo', false)
+            ->call('create')
+            ->assertHasErrors(['data.icao_code']);
+    }
+
+    public function testItDoesntCreateAnAirlineIcaoCodeTooLong()
+    {
+        Livewire::test(CreateAirline::class)
+            ->set('data.icao_code', Str::padRight('', 256, 'a'))
+            ->set('data.name', 'EasyJet')
+            ->set('data.callsign', 'EASY')
+            ->set('data.is_cargo', false)
+            ->call('create')
+            ->assertHasErrors(['data.icao_code']);
+    }
+
+    public function testItDoesntCreateAnAirlineNoName()
+    {
+        Livewire::test(CreateAirline::class)
+            ->set('data.icao_code', 'EZY')
+            ->set('data.callsign', 'EASY')
+            ->set('data.is_cargo', false)
+            ->call('create')
+            ->assertHasErrors(['data.name']);
+    }
+
+    public function testItDoesntCreateAnAirlineNameEmpty()
+    {
+        Livewire::test(CreateAirline::class)
+            ->set('data.icao_code', 'EZY')
+            ->set('data.name', '')
+            ->set('data.callsign', 'EASY')
+            ->set('data.is_cargo', false)
+            ->call('create')
+            ->assertHasErrors(['data.name']);
+    }
+
+    public function testItDoesntCreateAnAirlineNameTooLong()
+    {
+        Livewire::test(CreateAirline::class)
+            ->set('data.icao_code', 'EZY')
+            ->set('data.name', Str::padRight('', 256, 'a'))
+            ->set('data.callsign', 'EASY')
+            ->set('data.is_cargo', false)
+            ->call('create')
+            ->assertHasErrors(['data.name']);
+    }
+
+    public function testItDoesntCreateAnAirlineNoCallsign()
+    {
+        Livewire::test(CreateAirline::class)
+            ->set('data.icao_code', 'EZY')
+            ->set('data.name', 'EasyJet')
+            ->set('data.is_cargo', false)
+            ->call('create')
+            ->assertHasErrors(['data.callsign']);
+    }
+
+    public function testItDoesntCreateAnAirlineCallsignEmpty()
+    {
+        Livewire::test(CreateAirline::class)
+            ->set('data.icao_code', 'EZY')
+            ->set('data.name', 'EasyJet')
+            ->set('data.callsign', '')
+            ->set('data.is_cargo', false)
+            ->call('create')
+            ->assertHasErrors(['data.callsign']);
+    }
+
+    public function testItDoesntCreateAnAirlineCallsignTooLong()
+    {
+        Livewire::test(CreateAirline::class)
+            ->set('data.icao_code', 'EZY')
+            ->set('data.name', 'EasyJet')
+            ->set('data.callsign', Str::padRight('', 256, 'a'))
+            ->set('data.is_cargo', false)
+            ->call('create')
+            ->assertHasErrors(['data.callsign']);
+    }
+
+    public function testItLoadsDataForEdit()
+    {
+        Livewire::test(EditAirline::class, ['record' => 1])
+            ->assertSet('data.icao_code', 'BAW')
+            ->assertSet('data.name', 'British Airways')
+            ->assertSet('data.callsign', 'SPEEDBIRD')
+            ->assertSet('data.is_cargo', false);
+    }
+
+    public function testItEditsAnAirline()
+    {
+        Livewire::test(EditAirline::class, ['record' => 1])
+            ->set('data.icao_code', 'EZY')
+            ->set('data.name', 'EasyJet')
+            ->set('data.callsign', 'EASY')
+            ->set('data.is_cargo', false)
+            ->call('save')
+            ->assertHasNoErrors();
+
+        $this->assertDatabaseHas(
+            'airlines',
+            [
+                'id' => 1,
+                'icao_code' => 'EZY',
+                'name' => 'EasyJet',
+                'callsign' => 'EASY',
+                'is_cargo' => false,
+            ]
+        );
+    }
+
+    public function testItEditsACargoAirline()
+    {
+        Livewire::test(EditAirline::class, ['record' => 1])
+            ->set('data.icao_code', 'EZY')
+            ->set('data.name', 'EasyJet Cargo')
+            ->set('data.callsign', 'EASY')
+            ->set('data.is_cargo', true)
+            ->call('save')
+            ->assertHasNoErrors();
+
+        $this->assertDatabaseHas(
+            'airlines',
+            [
+                'id' => 1,
+                'icao_code' => 'EZY',
+                'name' => 'EasyJet Cargo',
+                'callsign' => 'EASY',
+                'is_cargo' => true,
+            ]
+        );
+    }
+
+    public function testItDoesntEditAnAirlineNoIcaoCode()
+    {
+        Livewire::test(EditAirline::class, ['record' => 1])
+            ->set('data.icao_code')
+            ->set('data.name', 'EasyJet')
+            ->set('data.callsign', 'EASY')
+            ->set('data.is_cargo', false)
+            ->call('save')
+            ->assertHasErrors(['data.icao_code']);
+    }
+
+    public function testItDoesntEditAnAirlineIcaoCodeEmpty()
+    {
+        Livewire::test(EditAirline::class, ['record' => 1])
+            ->set('data.icao_code', '')
+            ->set('data.name', 'EasyJet')
+            ->set('data.callsign', 'EASY')
+            ->set('data.is_cargo', false)
+            ->call('save')
+            ->assertHasErrors(['data.icao_code']);
+    }
+
+    public function testItDoesntEditAnAirlineIcaoCodeTooLong()
+    {
+        Livewire::test(EditAirline::class, ['record' => 1])
+            ->set('data.icao_code', Str::padRight('', 256, 'a'))
+            ->set('data.name', 'EasyJet')
+            ->set('data.callsign', 'EASY')
+            ->set('data.is_cargo', false)
+            ->call('save')
+            ->assertHasErrors(['data.icao_code']);
+    }
+
+    public function testItDoesntEditAnAirlineNoName()
+    {
+        Livewire::test(EditAirline::class, ['record' => 1])
+            ->set('data.icao_code', 'EZY')
+            ->set('data.name')
+            ->set('data.callsign', 'EASY')
+            ->set('data.is_cargo', false)
+            ->call('save')
+            ->assertHasErrors(['data.name']);
+    }
+
+    public function testItDoesntEditAnAirlineNameEmpty()
+    {
+        Livewire::test(EditAirline::class, ['record' => 1])
+            ->set('data.icao_code', 'EZY')
+            ->set('data.name', '')
+            ->set('data.callsign', 'EASY')
+            ->set('data.is_cargo', false)
+            ->call('save')
+            ->assertHasErrors(['data.name']);
+    }
+
+    public function testItDoesntEditAnAirlineNameTooLong()
+    {
+        Livewire::test(EditAirline::class, ['record' => 1])
+            ->set('data.icao_code', 'EZY')
+            ->set('data.name', Str::padRight('', 256, 'a'))
+            ->set('data.callsign', 'EASY')
+            ->set('data.is_cargo', false)
+            ->call('save')
+            ->assertHasErrors(['data.name']);
+    }
+
+    public function testItDoesntEditAnAirlineNoCallsign()
+    {
+        Livewire::test(EditAirline::class, ['record' => 1])
+            ->set('data.icao_code', 'EZY')
+            ->set('data.name', 'EasyJet')
+            ->set('data.callsign')
+            ->set('data.is_cargo', false)
+            ->call('save')
+            ->assertHasErrors(['data.callsign']);
+    }
+
+    public function testItDoesntEditAnAirlineCallsignEmpty()
+    {
+        Livewire::test(EditAirline::class, ['record' => 1])
+            ->set('data.icao_code', 'EZY')
+            ->set('data.name', 'EasyJet')
+            ->set('data.callsign', '')
+            ->set('data.is_cargo', false)
+            ->call('save')
+            ->assertHasErrors(['data.callsign']);
+    }
+
+    public function testItDoesntEditAnAirlineCallsignTooLong()
+    {
+        Livewire::test(EditAirline::class, ['record' => 1])
+            ->set('data.icao_code', 'EZY')
+            ->set('data.name', 'EasyJet')
+            ->set('data.callsign', Str::padRight('', 256, 'a'))
+            ->set('data.is_cargo', false)
+            ->call('save')
+            ->assertHasErrors(['data.callsign']);
+    }
+
+    protected function getCreateText(): string
+    {
+        return 'Create Airline';
+    }
+
+    protected function getEditRecord(): Model
+    {
+        return Airline::findOrFail(1);
+    }
+
+    protected function getEditText(): string
+    {
+        return 'Edit BAW';
+    }
+
+    protected function getIndexText(): array
+    {
+        return ['BAW', 'British Airways', 'SPEEDBIRD'];
+    }
+
+    protected function getViewText(): string
+    {
+        return 'View BAW';
+    }
+
+    protected function getViewRecord(): Model
+    {
+        return $this->getEditRecord();
+    }
+
+    protected function resourceClass(): string
+    {
+        return AirlineResource::class;
+    }
+
+    protected static function resourceRecordClass(): string
+    {
+        return Airline::class;
+    }
+
+    protected static function resourceId(): int|string
+    {
+        return 1;
+    }
+
+    protected static function writeResourcePageActions(): array
+    {
+        return [
+            'create',
+        ];
+    }
+
+    protected static function resourceListingClass(): string
+    {
+        return ListAirlines::class;
+    }
+
+    protected static function tableActionRecordClass(): array
+    {
+        return [
+        ];
+    }
+
+    protected static function tableActionRecordId(): array
+    {
+        return [
+        ];
+    }
+
+    protected static function writeTableActions(): array
+    {
+        return [
+        ];
+    }
+
+    protected static function writeResourceTableActions(): array
+    {
+        return [
+            'edit',
+        ];
+    }
+
+    protected static function readOnlyResourceTableActions(): array
+    {
+        return ['view'];
+    }
+}


### PR DESCRIPTION
- Add a filament resource for airlines
- Add on creation option for copying stands from another airline
- Add a relation manager to allow terminals to be assigned to airlines from the page of a particular airline
- Add a relation manager to allow stands to be assigned to airlines from the page of a particular airline