### PR TITLE
feat: ACARS messages

### DIFF
--- a/.env.ci
+++ b/.env.ci
@@ -57,3 +57,7 @@ CORE_SSO_CLIENT_SECRET=
 
 # SRD
 SRD_DOWNLOAD_URL="https://vatsim.uk/srd/%s/download"
+
+# ACARS
+HOPPIE_ACARS_LOGIN_CODE=testlogin
+ENABLE_ACARS_MESSAGES=false

--- a/.env.example
+++ b/.env.example
@@ -73,3 +73,7 @@ CORE_SSO_CLIENT_SECRET=secret
 
 # SRD
 SRD_DOWNLOAD_URL="https://vatsim.uk/srd/%s/download"
+
+# ACARS
+HOPPIE_ACARS_LOGIN_CODE=testlogin
+ENABLE_ACARS_MESSAGES=false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -177,6 +177,8 @@ jobs:
             # Install application dependencies
             $PHP_PATH artisan package:discover
             $PHP_PATH artisan filament:upgrade
+            $PHP_PATH artisan optimize
+            $PHP_PATH artisan event:cache
           envs: RELEASE_DIRECTORY,APPLICATION_ROOT,TAG,PHP_PATH
 
       - name: (Remote) Update symbolic links

--- a/app/Acars/Message/MessageInterface.php
+++ b/app/Acars/Message/MessageInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Acars\Message;
+
+interface MessageInterface
+{
+    /**
+     * Returns the intended target of the ACARS message.
+     */
+    public function getTarget(): string;
+}

--- a/app/Acars/Message/Telex/StandAssignedTelexMessage.php
+++ b/app/Acars/Message/Telex/StandAssignedTelexMessage.php
@@ -21,12 +21,13 @@ class StandAssignedTelexMessage implements TelexMessageInterface
     public function getBody(): string
     {
         return sprintf(
-            "VATSIM UK Stand Assignment\n" .
-            "--------------------------\n\n" .
             "You have been provisionally assigned stand %s.\n\n" .
             "This message is for planning purposes only, is non-binding, " .
             "and may change subject to availability and controller discretion.\n\n" .
-            "You will be notified if another assignment is made.",
+            "You will be notified if another assignment is made.\n\n" .
+            "Do not reply to this message, it is automatically generated.\n\n" .
+            "Safe landings!\n\n" .
+            "VATSIM UK",
             $this->getStandAssignmentString()
         );
     }

--- a/app/Acars/Message/Telex/StandAssignedTelexMessage.php
+++ b/app/Acars/Message/Telex/StandAssignedTelexMessage.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Acars\Message\Telex;
+
+use App\Models\Stand\StandAssignment;
+
+class StandAssignedTelexMessage implements TelexMessageInterface
+{
+    private StandAssignment $standAssignment;
+
+    public function __construct(StandAssignment $standAssignment)
+    {
+        $this->standAssignment = $standAssignment;
+    }
+
+    public function getTarget(): string
+    {
+        return $this->standAssignment->callsign;
+    }
+
+    public function getBody(): string
+    {
+        return sprintf(
+            "VATSIM UK Stand Assignment\n" .
+            "--------------------------\n\n" .
+            "You have been provisionally assigned stand %s.\n\n" .
+            "This message is for planning purposes only, is non-binding, " .
+            "and may change subject to availability and controller discretion.\n\n" .
+            "You will be notified if another assignment is made.",
+            $this->getStandAssignmentString()
+        );
+    }
+
+    private function getStandAssignmentString(): string
+    {
+        $stand = $this->standAssignment->stand;
+        return sprintf('%s/%s', $stand->airfield->code, $stand->identifier);
+    }
+}

--- a/app/Acars/Message/Telex/StandAssignedTelexMessage.php
+++ b/app/Acars/Message/Telex/StandAssignedTelexMessage.php
@@ -22,11 +22,7 @@ class StandAssignedTelexMessage implements TelexMessageInterface
     {
         return sprintf(
             "You have been provisionally assigned stand %s.\n\n" .
-            "This message is for planning purposes only, is non-binding, " .
-            "and may change subject to availability and controller discretion.\n\n" .
-            "You will be notified if another assignment is made.\n\n" .
-            "Do not reply to this message, it is automatically generated.\n\n" .
-            "Safe landings!\n\n" .
+            "Safe landings.\n\n" .
             "VATSIM UK",
             $this->getStandAssignmentString()
         );

--- a/app/Acars/Message/Telex/TelexMessageInterface.php
+++ b/app/Acars/Message/Telex/TelexMessageInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Acars\Message\Telex;
+
+use App\Acars\Message\MessageInterface;
+
+interface TelexMessageInterface extends MessageInterface
+{
+    /**
+     * Returns the body of the message.
+     */
+    public function getBody(): string;
+}

--- a/app/Acars/Provider/AcarsProviderInterface.php
+++ b/app/Acars/Provider/AcarsProviderInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Acars\Provider;
+
+use App\Acars\Exception\AcarsRequestException;
+use App\Acars\Message\Telex\TelexMessageInterface;
+
+interface AcarsProviderInterface
+{
+    /**
+     * Sends a TELEX message.
+     *
+     * @throws AcarsRequestException
+     */
+    public function sendTelex(TelexMessageInterface $message): void;
+}

--- a/app/Acars/Provider/HoppieAcarsProvider.php
+++ b/app/Acars/Provider/HoppieAcarsProvider.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Acars\Provider;
+
+use App\Acars\Exception\AcarsRequestException;
+use App\Acars\Message\Telex\TelexMessageInterface;
+use App\Models\Acars\AcarsMessage;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+class HoppieAcarsProvider implements AcarsProviderInterface
+{
+    private const ONLINE_CALLSIGNS_CACHE_KEY = 'HOPPIE_ACARS_ONLINE_CALLSIGNS';
+    private const ONLINE_CALLSIGNS_CACHE_DURATION_SECONDS = 120;
+    private const VATUK_STATION_IDENTIFIER = 'VATSIMUK';
+
+    public function sendTelex(TelexMessageInterface $message): void
+    {
+        if ($this->getOnlineCallsigns()->doesntContain($message->getTarget())) {
+            return;
+        }
+
+        $this->makeRequest('telex', $message->getTarget(), $message->getBody());
+    }
+
+    private function getOnlineCallsigns(): Collection
+    {
+        return Cache::remember(
+            self::ONLINE_CALLSIGNS_CACHE_KEY,
+            self::ONLINE_CALLSIGNS_CACHE_DURATION_SECONDS,
+            function () {
+                $responseBody = $this->getResponseBody(
+                    $this->makeRequest('ping', self::VATUK_STATION_IDENTIFIER, 'ALL-CALLSIGNS')
+                );
+                return collect($responseBody === '' ? [] : explode(' ', $responseBody));
+            }
+        );
+    }
+
+    private function makeRequest(string $messageType, string $target, string $data): Response
+    {
+        $message = $this->buildRequestBody($messageType, $target, $data);
+        return tap(
+            Http::asForm()->timeout(3)->post(
+                config('acars.hoppie.url'),
+                $message
+            ),
+            function (Response $response) use ($message) {
+                $success = $this->responseSuccessful($response);
+
+                AcarsMessage::create(
+                    [
+                        'message' => http_build_query($message),
+                        'successful' => $success,
+                    ]
+                );
+
+                if (!$success) {
+                    $errorMessage = sprintf('Acars request failed, response: %s', $response->body());
+                    Log::error($errorMessage);
+                    throw new AcarsRequestException($errorMessage);
+                }
+            }
+        );
+    }
+
+    private function buildRequestBody(string $messageType, string $target, string $data): array
+    {
+        return [
+            'logon' => config('acars.hoppie.login_code'),
+            'type' => $messageType,
+            'to' => $target,
+            'from' => self::VATUK_STATION_IDENTIFIER,
+            'packet' => $data,
+        ];
+    }
+
+    private function getResponseBody(Response $response): string
+    {
+        return Str::substr($response->body(), 4, -1);
+    }
+
+    private function responseSuccessful(Response $response): bool
+    {
+        return $response->successful() && Str::substr($response, 0, 2) === 'ok';
+    }
+}

--- a/app/Acars/Provider/HoppieAcarsProvider.php
+++ b/app/Acars/Provider/HoppieAcarsProvider.php
@@ -53,7 +53,8 @@ class HoppieAcarsProvider implements AcarsProviderInterface
                 $success = $this->responseSuccessful($response);
                 $messageWithoutLogon = array_filter(
                     $message,
-                    fn(string $key) => $key !== 'logon', ARRAY_FILTER_USE_KEY
+                    fn (string $key) => $key !== 'logon',
+                    ARRAY_FILTER_USE_KEY
                 );
 
                 AcarsMessage::create(

--- a/app/Acars/Provider/HoppieAcarsProvider.php
+++ b/app/Acars/Provider/HoppieAcarsProvider.php
@@ -51,10 +51,14 @@ class HoppieAcarsProvider implements AcarsProviderInterface
             ),
             function (Response $response) use ($message) {
                 $success = $this->responseSuccessful($response);
+                $messageWithoutLogon = array_filter(
+                    $message,
+                    fn(string $key) => $key !== 'logon', ARRAY_FILTER_USE_KEY
+                );
 
                 AcarsMessage::create(
                     [
-                        'message' => http_build_query($message),
+                        'message' => http_build_query($messageWithoutLogon),
                         'successful' => $success,
                     ]
                 );

--- a/app/Console/Commands/OptimiseTables.php
+++ b/app/Console/Commands/OptimiseTables.php
@@ -29,6 +29,7 @@ class OptimiseTables extends Command
         'failed_jobs',
         'navaid_network_aircraft',
         'monitored_scheduled_task_log_items',
+        'acars_messages',
     ];
 
     protected $signature = 'tables:optimise';

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -76,6 +76,7 @@ class Kernel extends ConsoleKernel
     protected function schedule(Schedule $schedule)
     {
         $schedule->command('model:prune', ['--model' => MonitoredScheduledTaskLogItem::class])->daily()->doNotMonitor();
+        $schedule->command('model:prune')->daily()->doNotMonitor();
         $schedule->command('tokens:delete-expired')->daily()->doNotMonitor();
         $schedule->command('squawks:clean-history')->daily()->doNotMonitor();
         $schedule->command('stands:clean-history')->daily()->doNotMonitor();

--- a/app/Filament/Pages/UserPreferences.php
+++ b/app/Filament/Pages/UserPreferences.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use App\Filament\Resources\TranslatesStrings;
+use App\Models\User\User;
+use Filament\Forms\Components\Toggle;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Pages\Page;
+use Illuminate\Support\Facades\Auth;
+
+class UserPreferences extends Page
+{
+    use InteractsWithForms;
+    use TranslatesStrings;
+
+    protected static ?string $navigationIcon = 'heroicon-o-document-text';
+    protected static ?string $navigationGroup = 'Preferences';
+
+    protected static string $view = 'filament.pages.user-preferences';
+
+    protected User $user;
+
+    public function mount(): void
+    {
+        $this->form->fill([
+            'send_stand_acars_messages' => $this->user->send_stand_acars_messages,
+        ]);
+    }
+
+    protected function getFormSchema(): array
+    {
+        return [
+            Toggle::make('send_stand_acars_messages')
+                ->label(self::translateFormPath('user_preferences.acars.label'))
+                ->helperText(self::translateFormPath('user_preferences.acars.helper'))
+                ->reactive()
+                ->afterStateUpdated(function () {
+                    $this->submit();
+                })
+        ];
+    }
+
+    public function submit(): void
+    {
+        $this->getFormModel()->update($this->form->getState());
+    }
+
+    protected function getFormModel(): User
+    {
+        return tap(
+            Auth::user(),
+            function (User $user) {
+                $this->user = $user;
+            }
+        );
+    }
+
+    protected static function translationPathRoot(): string
+    {
+        return 'stands';
+    }
+}

--- a/app/Filament/Pages/UserPreferences.php
+++ b/app/Filament/Pages/UserPreferences.php
@@ -4,6 +4,7 @@ namespace App\Filament\Pages;
 
 use App\Filament\Resources\TranslatesStrings;
 use App\Models\User\User;
+use Filament\Forms\Components\Fieldset;
 use Filament\Forms\Components\Toggle;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Pages\Page;
@@ -28,19 +29,31 @@ class UserPreferences extends Page
     {
         $this->form->fill([
             'send_stand_acars_messages' => $this->user->send_stand_acars_messages,
+            'stand_acars_messages_uncontrolled_airfield' => $this->user->stand_acars_messages_uncontrolled_airfield,
         ]);
     }
 
     protected function getFormSchema(): array
     {
         return [
-            Toggle::make('send_stand_acars_messages')
-                ->label(self::translateFormPath('user_preferences.acars.label'))
-                ->helperText(self::translateFormPath('user_preferences.acars.helper'))
-                ->reactive()
-                ->afterStateUpdated(function () {
-                    $this->submit();
-                })
+            Fieldset::make('stand_acars')
+                ->label(self::translateFormPath('user_preferences.acars_heading.label'))
+                ->schema([
+                    Toggle::make('send_stand_acars_messages')
+                        ->label(self::translateFormPath('user_preferences.acars.label'))
+                        ->helperText(self::translateFormPath('user_preferences.acars.helper'))
+                        ->reactive()
+                        ->afterStateUpdated(function () {
+                            $this->submit();
+                        }),
+                    Toggle::make('stand_acars_messages_uncontrolled_airfield')
+                        ->label(self::translateFormPath('user_preferences.acars_uncontrolled.label'))
+                        ->helperText(self::translateFormPath('user_preferences.acars_uncontrolled.helper'))
+                        ->reactive()
+                        ->afterStateUpdated(function () {
+                            $this->submit();
+                        }),
+                ]),
         ];
     }
 

--- a/app/Filament/Pages/UserPreferences.php
+++ b/app/Filament/Pages/UserPreferences.php
@@ -16,6 +16,9 @@ class UserPreferences extends Page
 
     protected static ?string $navigationIcon = 'heroicon-o-document-text';
     protected static ?string $navigationGroup = 'Preferences';
+    protected static ?string $navigationLabel = 'My Preferences';
+    protected static ?string $title = 'My Preferences';
+    protected static ?string $slug = 'my-preferences';
 
     protected static string $view = 'filament.pages.user-preferences';
 

--- a/app/Listeners/Stand/SendStandAllocationAcarsMessage.php
+++ b/app/Listeners/Stand/SendStandAllocationAcarsMessage.php
@@ -70,11 +70,11 @@ class SendStandAllocationAcarsMessage
         $aircraft = $assignment->aircraft;
         $airfield = $assignment->stand->airfield;
         return $airfield && $aircraft && LocationService::metersToNauticalMiles(
-                $airfield->coordinate->getDistance(
-                    $aircraft->latLong,
-                    new Haversine()
-                )
-            ) > self::MIN_ASSIGNMENT_DISTANCE_NAUTICAL_MILES;
+            $airfield->coordinate->getDistance(
+                $aircraft->latLong,
+                new Haversine()
+            )
+        ) > self::MIN_ASSIGNMENT_DISTANCE_NAUTICAL_MILES;
     }
 
     private function notArrivingAndDepartingSameAirport(StandAssignment $assignment): bool
@@ -106,7 +106,7 @@ class SendStandAllocationAcarsMessage
         $airfield = $assignment->stand->airfield;
         return NetworkControllerPosition::whereIn(
             'controller_position_id',
-            $airfield->controllers->reject(fn(ControllerPosition $position) => $position->isDelivery())->pluck('id')
+            $airfield->controllers->reject(fn (ControllerPosition $position) => $position->isDelivery())->pluck('id')
         )->exists();
     }
 }

--- a/app/Listeners/Stand/SendStandAllocationAcarsMessage.php
+++ b/app/Listeners/Stand/SendStandAllocationAcarsMessage.php
@@ -58,11 +58,11 @@ class SendStandAllocationAcarsMessage
         $aircraft = $assignment->aircraft;
         $airfield = $assignment->stand->airfield;
         return $airfield && $aircraft && LocationService::metersToNauticalMiles(
-                $airfield->coordinate->getDistance(
-                    $aircraft->latLong,
-                    new Haversine()
-                )
-            ) > self::MIN_ASSIGNMENT_DISTANCE_NAUTICAL_MILES;
+            $airfield->coordinate->getDistance(
+                $aircraft->latLong,
+                new Haversine()
+            )
+        ) > self::MIN_ASSIGNMENT_DISTANCE_NAUTICAL_MILES;
     }
 
     private function notArrivingAndDepartingSameAirport(StandAssignment $assignment): bool

--- a/app/Listeners/Stand/SendStandAllocationAcarsMessage.php
+++ b/app/Listeners/Stand/SendStandAllocationAcarsMessage.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Listeners\Stand;
+
+use App\Acars\Exception\AcarsRequestException;
+use App\Acars\Message\Telex\StandAssignedTelexMessage;
+use App\Acars\Provider\AcarsProviderInterface;
+use App\Events\StandAssignedEvent;
+use App\Models\Stand\StandAssignment;
+use Illuminate\Support\Facades\Log;
+use Location\Distance\Haversine;
+
+class SendStandAllocationAcarsMessage
+{
+    private const MIN_ASSIGNMENT_DISTANCE = 7.5;
+
+    private readonly AcarsProviderInterface $acarsProvider;
+
+    public function __construct(AcarsProviderInterface $acarsProvider)
+    {
+        $this->acarsProvider = $acarsProvider;
+    }
+
+    public function handle(StandAssignedEvent $assignedEvent)
+    {
+        if (!$this->standAcarsMessagesAreEnabled()) {
+            return;
+        }
+
+        $standAssignment = $assignedEvent->getStandAssignment();
+        if (!$this->userAllowsStandAllocationMessages($standAssignment)) {
+            return;
+        }
+
+        if (!$this->meetsSendingConditions($standAssignment)) {
+            return;
+        }
+
+        try {
+            $this->acarsProvider->sendTelex(new StandAssignedTelexMessage($standAssignment));
+        } catch (AcarsRequestException $requestException) {
+            Log::error(sprintf('Acars exception sending stand allocation message: %s', $requestException->getMessage()));
+        }
+    }
+
+    private function meetsSendingConditions(StandAssignment $assignment): bool
+    {
+        return $this->standIsAtArrivalAirport($assignment) &&
+            $this->notArrivingAndDepartingSameAirport($assignment) &&
+            $this->aircraftIsNotTooCloseToDestination($assignment);
+    }
+
+    private function aircraftIsNotTooCloseToDestination(StandAssignment $assignment): bool
+    {
+        $aircraft = $assignment->aircraft;
+        $airfield = $assignment->aifield;
+        return $airfield && $aircraft && $airfield->coordinate->getDistance(
+            $aircraft->latLong,
+                new Haversine()
+        ) > self::MIN_ASSIGNMENT_DISTANCE;
+    }
+
+    private function notArrivingAndDepartingSameAirport(StandAssignment $assignment): bool
+    {
+        return $assignment->aircraft->planned_depairport !== $assignment->aircraft->planned_destairport;
+    }
+
+    private function standIsAtArrivalAirport(StandAssignment $assignment): bool
+    {
+        return $assignment->stand->airport->code === $assignment->aircraft->planned_destairport;
+    }
+
+    private function standAcarsMessagesAreEnabled(): bool
+    {
+        return config('assignment_acars_message') === true;
+    }
+
+    private function userAllowsStandAllocationMessages(StandAssignment $standAssignment): bool
+    {
+        return $standAssignment->aircraft?->user !== null;
+    }
+}

--- a/app/Listeners/Stand/SendStandAllocationAcarsMessage.php
+++ b/app/Listeners/Stand/SendStandAllocationAcarsMessage.php
@@ -48,9 +48,18 @@ class SendStandAllocationAcarsMessage
 
     private function meetsSendingConditions(StandAssignment $assignment): bool
     {
-        return $this->standIsAtArrivalAirport($assignment) &&
+        return $this->aircraftIsNotSweatbox($assignment) &&
+            $this->standIsAtArrivalAirport($assignment) &&
             $this->notArrivingAndDepartingSameAirport($assignment) &&
             $this->aircraftIsNotTooCloseToDestination($assignment);
+    }
+
+    /**
+     * For now, we know an aircraft isn't Sweatbox if we have a lat/long for it.
+     */
+    private function aircraftIsNotSweatbox(StandAssignment $assignment): bool
+    {
+        return isset($assignment->aircraft->latitude, $assignment->aircraft->longitude);
     }
 
     private function aircraftIsNotTooCloseToDestination(StandAssignment $assignment): bool

--- a/app/Models/Acars/AcarsMessage.php
+++ b/app/Models/Acars/AcarsMessage.php
@@ -2,10 +2,15 @@
 
 namespace App\Models\Acars;
 
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\MassPrunable;
 use Illuminate\Database\Eloquent\Model;
 
 class AcarsMessage extends Model
 {
+    use MassPrunable;
+
     protected $dates = [
         'created_at',
         'updated_at',
@@ -19,4 +24,9 @@ class AcarsMessage extends Model
     protected $casts = [
         'successful' => 'boolean',
     ];
+
+    public function prunable(): Builder
+    {
+        return static::where('created_at', '<', Carbon::now()->subMonth());
+    }
 }

--- a/app/Models/Acars/AcarsMessage.php
+++ b/app/Models/Acars/AcarsMessage.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models\Acars;
+
+use Illuminate\Database\Eloquent\Model;
+
+class AcarsMessage extends Model
+{
+    protected $dates = [
+        'created_at',
+        'updated_at',
+    ];
+
+    protected $fillable = [
+        'message',
+        'successful',
+    ];
+
+    protected $casts = [
+        'successful' => 'boolean',
+    ];
+}

--- a/app/Models/Controller/ControllerPosition.php
+++ b/app/Models/Controller/ControllerPosition.php
@@ -118,6 +118,11 @@ class ControllerPosition extends Model implements ControllerPositionInterface
         return (float) $this->frequency;
     }
 
+    public function isDelivery(): bool
+    {
+        return Str::contains($this->callsign, '_DEL');
+    }
+
     public function isApproach(): bool
     {
         return Str::contains($this->callsign, '_APP');

--- a/app/Models/User/User.php
+++ b/app/Models/User/User.php
@@ -52,6 +52,10 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
         'last_login_ip',
     ];
 
+    protected $casts = [
+        'send_stand_acars_messages' => 'boolean',
+    ];
+
     /**
      * Returns the relation to the users status
      *

--- a/app/Models/User/User.php
+++ b/app/Models/User/User.php
@@ -46,6 +46,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
         'last_name',
         'last_login',
         'send_stand_acars_messages',
+        'stand_acars_messages_uncontrolled_airfield',
     ];
     
     protected $hidden = [

--- a/app/Models/User/User.php
+++ b/app/Models/User/User.php
@@ -45,6 +45,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
         'first_name',
         'last_name',
         'last_login',
+        'send_stand_acars_messages',
     ];
     
     protected $hidden = [

--- a/app/Models/Vatsim/NetworkAircraft.php
+++ b/app/Models/Vatsim/NetworkAircraft.php
@@ -7,6 +7,7 @@ use App\Models\Hold\NavaidNetworkAircraft;
 use App\Models\Navigation\Navaid;
 use App\Models\Stand\Stand;
 use App\Models\Stand\StandAssignment;
+use App\Models\User\User;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -148,5 +149,10 @@ class NetworkAircraft extends Model
             'planned_destairport',
             'code'
         );
+    }
+
+    public function user(): HasOne
+    {
+        return $this->hasOne(User::class, 'cid');
     }
 }

--- a/app/Models/Vatsim/NetworkAircraft.php
+++ b/app/Models/Vatsim/NetworkAircraft.php
@@ -153,6 +153,6 @@ class NetworkAircraft extends Model
 
     public function user(): HasOne
     {
-        return $this->hasOne(User::class, 'cid');
+        return $this->hasOne(User::class, 'id', 'cid');
     }
 }

--- a/app/Providers/AcarsServiceProvider.php
+++ b/app/Providers/AcarsServiceProvider.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Providers;
+
+use App\Acars\Provider\AcarsProviderInterface;
+use App\Acars\Provider\HoppieAcarsProvider;
+use Illuminate\Support\ServiceProvider;
+
+class AcarsServiceProvider extends ServiceProvider
+{
+    public function boot()
+    {
+        $this->app->singleton(AcarsProviderInterface::class, HoppieAcarsProvider::class);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -73,6 +73,7 @@ class AppServiceProvider extends ServiceProvider
             Filament::registerTheme(mix('css/vatukfilament.css'));
             Filament::registerNavigationGroups(
                 [
+                    'Preferences',
                     'Airline',
                     'Airfield',
                     'Controller',

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -86,4 +86,9 @@ class EventServiceProvider extends ServiceProvider
         Runway::class => SelectOptionsObserver::class,
         WakeCategoryScheme::class => SelectOptionsObserver::class,
     ];
+
+    public function shouldDiscoverEvents(): bool
+    {
+        return true;
+    }
 }

--- a/config/acars.php
+++ b/config/acars.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'hoppie' => [
+        'url' => 'https://www.hoppie.nl/acars/system/connect.html',
+        'login_code' => env('HOPPIE_ACARS_LOGIN_CODE'),
+    ],
+];

--- a/config/app.php
+++ b/config/app.php
@@ -172,6 +172,7 @@ return [
         /*
          * Application Service Providers...
          */
+        App\Providers\AcarsServiceProvider::class,
         App\Providers\AppServiceProvider::class,
         App\Providers\AuthServiceProvider::class,
         App\Providers\BroadcastServiceProvider::class,

--- a/config/stands.php
+++ b/config/stands.php
@@ -1,5 +1,6 @@
 <?php
 
 return [
-    'auto_allocate' => env('AUTO_ALLOCATE_STANDS', false)
+    'auto_allocate' => env('AUTO_ALLOCATE_STANDS', false),
+    'assignment_acars_message' => env('SEND_STAND_ACARS_MESSAGES', true),
 ];

--- a/database/migrations/2023_04_20_181036_create_acars_messages_table.php
+++ b/database/migrations/2023_04_20_181036_create_acars_messages_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class extends Migration {
     /**
      * Run the migrations.
      *

--- a/database/migrations/2023_04_20_181036_create_acars_messages_table.php
+++ b/database/migrations/2023_04_20_181036_create_acars_messages_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('acars_messages', function (Blueprint $table) {
+            $table->id();
+            $table->text('message')->comment('The message itself');
+            $table->boolean('successful')->comment('Was the message successfully sent to the server');
+            $table->timestamps();
+
+            $table->index('created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('acars_messages');
+    }
+};

--- a/database/migrations/2023_04_21_153628_add_send_stand_acars_messages_to_user_table.php
+++ b/database/migrations/2023_04_21_153628_add_send_stand_acars_messages_to_user_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class extends Migration {
     /**
      * Run the migrations.
      */

--- a/database/migrations/2023_04_21_153628_add_send_stand_acars_messages_to_user_table.php
+++ b/database/migrations/2023_04_21_153628_add_send_stand_acars_messages_to_user_table.php
@@ -13,6 +13,7 @@ return new class extends Migration
     {
         Schema::table('user', function (Blueprint $table) {
             $table->boolean('send_stand_acars_messages')
+                ->default(false)
                 ->comment('Whether the user wants to be sent acars messages related to stand assignments');
         });
     }

--- a/database/migrations/2023_04_21_153628_add_send_stand_acars_messages_to_user_table.php
+++ b/database/migrations/2023_04_21_153628_add_send_stand_acars_messages_to_user_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('user', function (Blueprint $table) {
+            $table->boolean('send_stand_acars_messages')
+                ->comment('Whether the user wants to be sent acars messages related to stand assignments');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('user', function (Blueprint $table) {
+            $table->dropColumn('send_stand_acars_messages');
+        });
+    }
+};

--- a/database/migrations/2023_05_01_132807_add_stand_acars_message_uncontrolled_airports_column_to_user_table.php
+++ b/database/migrations/2023_05_01_132807_add_stand_acars_message_uncontrolled_airports_column_to_user_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('user', function (Blueprint $table) {
+            $table->boolean('stand_acars_messages_uncontrolled_airfield')
+                ->default(false)
+                ->comment(
+                    'Whether the user wants to be sent acars messages related to stand assignments at uncontrolled ' .
+                    'airfields'
+                );
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('user', function (Blueprint $table) {
+            $table->dropColumn('stand_acars_messages_uncontrolled_airfield');
+        });
+    }
+};

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -153,6 +153,7 @@ class DatabaseSeeder extends Seeder
         'missed_approach_notifications',
         'network_controller_positions',
         'controller_position_alternative_callsigns',
+        'acars_messages',
     ];
 
 

--- a/lang/en/stands/form.php
+++ b/lang/en/stands/form.php
@@ -7,7 +7,7 @@ return [
     'terminal' => [
         'label' => 'Terminal',
         'helper' => 'Some airfields allocate airlines by terminal rather than specific stands. You can assign stands ' .
-        'to terminals here.',
+            'to terminals here.',
     ],
     'identifier' => [
         'label' => 'Identifier',
@@ -16,7 +16,7 @@ return [
     'type' => [
         'label' => 'Type',
         'helper' => 'At airfields where certain stands are designated for only domestic or international flights, ' .
-        'this option can be selected to designate the type of stand.',
+            'this option can be selected to designate the type of stand.',
     ],
     'latitude' => [
         'label' => 'Latitude',
@@ -29,7 +29,7 @@ return [
     'wake_category' => [
         'label' => 'Maximum UK Wake Category',
         'helper' => 'Maximum UK WTC that can be assigned to this stand. Used as a fallback if no specific ' .
-        'aircraft type if specified.',
+            'aircraft type if specified.',
     ],
     'aircraft_type' => [
         'label' => 'Maximum Aircraft Type',
@@ -38,7 +38,7 @@ return [
     'used_for_allocation' => [
         'label' => 'Used for Allocation',
         'helper' => 'Stands not used for allocation will not be allocated by the automatic allocator ' .
-        'or be available for controllers to assign.',
+            'or be available for controllers to assign.',
     ],
     'allocation_priority' => [
         'label' => 'Allocation Priority',
@@ -54,20 +54,20 @@ return [
         ],
         'destination' => [
             'label' => 'Destination',
-            'helper' => 'The destination used for this allocation. Can be partial matches, for example, "EGJ".'
+            'helper' => 'The destination used for this allocation. Can be partial matches, for example, "EGJ".',
         ],
         'callsign' => [
             'label' => 'Callsign Slug',
-            'helper' => 'The part of the callsign after the ICAO code for this allocation. Can be partial matches.'
+            'helper' => 'The part of the callsign after the ICAO code for this allocation. Can be partial matches.',
         ],
         'priority' => [
             'label' => 'Allocation Priority',
             'helper' => 'Priority for allocating this stand, lower value is higher priority. ' .
-            'Considered before general allocation priority. Minimum 1, maximum 9999.'
+                'Considered before general allocation priority. Minimum 1, maximum 9999.',
         ],
         'not_before' => [
             'label' => 'Do not allocate before (UTC)',
-            'helper' => 'Will not allocate this stand automatically for arrivals before this time.'
+            'helper' => 'Will not allocate this stand automatically for arrivals before this time.',
         ],
         'remove' => [
             'label' => 'Remove',
@@ -76,7 +76,7 @@ return [
     'paired' => [
         'stand' => [
             'label' => 'Stand to Pair',
-            'helper' => 'Only stands at the same airfield may be paired.'
+            'helper' => 'Only stands at the same airfield may be paired.',
         ],
         'add' => [
             'label' => 'Add Paired Stand',
@@ -86,9 +86,17 @@ return [
         ],
     ],
     'user_preferences' => [
+        'acars_heading' => [
+            'label' => 'ACARS Settings',
+        ],
         'acars' => [
             'label' => 'Send ACARS messages for arrival stands',
-            'helper' => 'If this setting is turned on, then you will automatically be sent an ACARS message via Hoppie whenever an arrival stand is allocated for you.',
+            'helper' => 'If this setting is turned on, then you will automatically be sent an ACARS message via Hoppie whenever an arrival stand is allocated for you. ' .
+                'Messages will be sent only if the airfield is controlled by Ground or higher.',
+        ],
+        'acars_uncontrolled' => [
+            'label' => 'Send ACARS messages for arrival stands at uncontrolled airfields',
+            'helper' => 'If this setting is turned on, then ACARS messages for arrival stands will be sent at uncontrolled airfields.',
         ],
     ],
 ];

--- a/lang/en/stands/form.php
+++ b/lang/en/stands/form.php
@@ -85,4 +85,10 @@ return [
             'label' => 'Unpair',
         ],
     ],
+    'user_preferences' => [
+        'acars' => [
+            'label' => 'Send ACARS messages for arrival stands',
+            'helper' => 'If this setting is turned on, then you will automatically be sent an ACARS message via Hoppie whenever an arrival stand is allocated for you.',
+        ],
+    ],
 ];

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="tests/bootstrap.php" colors="true" processIsolation="false" stopOnFailure="false" failOnRisky="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
-  <coverage>
-    <include>
-      <directory suffix=".php">./app</directory>
-    </include>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="tests/bootstrap.php" colors="true" processIsolation="false" stopOnFailure="false" failOnRisky="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <coverage/>
   <testsuites>
     <testsuite name="tests">
       <directory suffix="Test.php">./tests</directory>
@@ -13,4 +9,9 @@
   <php>
     <env name="APP_ENV" value="testing"/>
   </php>
+  <source>
+    <include>
+      <directory suffix=".php">./app</directory>
+    </include>
+  </source>
 </phpunit>

--- a/resources/views/filament/pages/user-preferences.blade.php
+++ b/resources/views/filament/pages/user-preferences.blade.php
@@ -1,0 +1,5 @@
+<x-filament::page>
+    <form wire:submit.prevent="submit">
+        {{ $this->form }}
+    </form>
+</x-filament::page>

--- a/tests/app/Acars/Exception/AcarsRequestException.php
+++ b/tests/app/Acars/Exception/AcarsRequestException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Acars\Exception;
+
+use Exception;
+
+class AcarsRequestException extends Exception
+{
+
+}

--- a/tests/app/Acars/Message/Telex/StandAssignedTelexMessageTest.php
+++ b/tests/app/Acars/Message/Telex/StandAssignedTelexMessageTest.php
@@ -31,14 +31,17 @@ class StandAssignedTelexMessageTest extends BaseFunctionalTestCase
     public function testItHasAMessage()
     {
         $expected = <<<END
-VATSIM UK Stand Assignment
---------------------------
-
 You have been provisionally assigned stand EGLL/251.
 
 This message is for planning purposes only, is non-binding, and may change subject to availability and controller discretion.
 
 You will be notified if another assignment is made.
+
+Do not reply to this message, it is automatically generated.
+
+Safe landings!
+
+VATSIM UK
 END;
 
         $expected = Str::replace("\r\n", "\n", $expected);

--- a/tests/app/Acars/Message/Telex/StandAssignedTelexMessageTest.php
+++ b/tests/app/Acars/Message/Telex/StandAssignedTelexMessageTest.php
@@ -33,13 +33,7 @@ class StandAssignedTelexMessageTest extends BaseFunctionalTestCase
         $expected = <<<END
 You have been provisionally assigned stand EGLL/251.
 
-This message is for planning purposes only, is non-binding, and may change subject to availability and controller discretion.
-
-You will be notified if another assignment is made.
-
-Do not reply to this message, it is automatically generated.
-
-Safe landings!
+Safe landings.
 
 VATSIM UK
 END;

--- a/tests/app/Acars/Message/Telex/StandAssignedTelexMessageTest.php
+++ b/tests/app/Acars/Message/Telex/StandAssignedTelexMessageTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Acars\Message\Telex;
+
+use App\BaseFunctionalTestCase;
+use App\Models\Stand\StandAssignment;
+use Illuminate\Support\Str;
+
+class StandAssignedTelexMessageTest extends BaseFunctionalTestCase
+{
+    private StandAssignment $assignment;
+    private StandAssignedTelexMessage $message;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->assignment = StandAssignment::create(
+            [
+                'callsign' => 'BAW123',
+                'stand_id' => 2,
+            ]
+        );
+        $this->message = new StandAssignedTelexMessage($this->assignment);
+    }
+
+    public function testItHasATarget()
+    {
+        $this->assertEquals('BAW123', $this->message->getTarget());
+    }
+
+    public function testItHasAMessage()
+    {
+        $expected = <<<END
+VATSIM UK Stand Assignment
+--------------------------
+
+You have been provisionally assigned stand EGLL/251.
+
+This message is for planning purposes only, is non-binding, and may change subject to availability and controller discretion.
+
+You will be notified if another assignment is made.
+END;
+
+        $expected = Str::replace("\r\n", "\n", $expected);
+        $this->assertEquals($expected, $this->message->getBody());
+    }
+}

--- a/tests/app/Acars/Provider/HoppieAcarsProviderTest.php
+++ b/tests/app/Acars/Provider/HoppieAcarsProviderTest.php
@@ -50,10 +50,7 @@ class HoppieAcarsProviderTest extends BaseFunctionalTestCase
             $loggedMessage = AcarsMessage::find(AcarsMessage::max('id'));
             $this->assertEquals(
                 $loggedMessage->message,
-                sprintf(
-                    'logon=%s&type=telex&to=BAW123&from=VATSIMUK&packet=TEST',
-                    config('acars.hoppie.login_code')
-                )
+                'type=telex&to=BAW123&from=VATSIMUK&packet=TEST'
             );
             $this->assertFalse($loggedMessage->successful);
             return;
@@ -79,10 +76,7 @@ class HoppieAcarsProviderTest extends BaseFunctionalTestCase
             $loggedMessage = AcarsMessage::find(AcarsMessage::max('id'));
             $this->assertEquals(
                 $loggedMessage->message,
-                sprintf(
-                    'logon=%s&type=telex&to=BAW123&from=VATSIMUK&packet=TEST',
-                    config('acars.hoppie.login_code')
-                )
+                'type=telex&to=BAW123&from=VATSIMUK&packet=TEST'
             );
             $this->assertFalse($loggedMessage->successful);
             return;

--- a/tests/app/Acars/Provider/HoppieAcarsProviderTest.php
+++ b/tests/app/Acars/Provider/HoppieAcarsProviderTest.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace App\Acars\Provider;
+
+use App\Acars\Message\Telex\TelexMessageInterface;
+use App\BaseFunctionalTestCase;
+use App\Acars\Exception\AcarsRequestException;
+use App\Models\Acars\AcarsMessage;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Mockery;
+
+class HoppieAcarsProviderTest extends BaseFunctionalTestCase
+{
+    private readonly HoppieAcarsProvider $provider;
+
+    private const CACHE_KEY = 'HOPPIE_ACARS_ONLINE_CALLSIGNS';
+
+    private readonly TelexMessageInterface $mockTelex;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->provider = $this->app->make(HoppieAcarsProvider::class);
+        Http::preventStrayRequests();
+        $this->mockTelex = Mockery::mock(TelexMessageInterface::class);
+    }
+
+    public function tearDown(): void
+    {
+        Cache::forget(self::CACHE_KEY);
+        parent::tearDown();
+    }
+
+    public function testItThrowsExceptionOnRequestError()
+    {
+        Cache::set(self::CACHE_KEY, collect(['BAW123', 'BAW456']), 300);
+        try {
+            Http::fake(
+                [
+                    config('acars.hoppie.url') => Http::response('ok {}', 500),
+                ]
+            );
+
+            $this->mockTelex->shouldReceive('getTarget')->andReturn('BAW123');
+            $this->mockTelex->shouldReceive('getBody')->andReturn('TEST');
+            $this->provider->sendTelex($this->mockTelex);
+        } catch (AcarsRequestException) {
+            $loggedMessage = AcarsMessage::find(AcarsMessage::max('id'));
+            $this->assertEquals(
+                $loggedMessage->message,
+                sprintf(
+                    'logon=%s&type=telex&to=BAW123&from=VATSIMUK&packet=TEST',
+                    config('acars.hoppie.login_code')
+                )
+            );
+            $this->assertFalse($loggedMessage->successful);
+            return;
+        }
+
+        self::fail('Expected an AcarsRequestException but did not get one');
+    }
+
+    public function testItThrowsExceptionOnBadResponse()
+    {
+        Cache::set(self::CACHE_KEY, collect(['BAW123', 'BAW456']), 300);
+        try {
+            Http::fake(
+                [
+                    config('acars.hoppie.url') => Http::response('notok {}'),
+                ]
+            );
+
+            $this->mockTelex->shouldReceive('getTarget')->andReturn('BAW123');
+            $this->mockTelex->shouldReceive('getBody')->andReturn('TEST');
+            $this->provider->sendTelex($this->mockTelex);
+        } catch (AcarsRequestException $exception) {
+            $loggedMessage = AcarsMessage::find(AcarsMessage::max('id'));
+            $this->assertEquals(
+                $loggedMessage->message,
+                sprintf(
+                    'logon=%s&type=telex&to=BAW123&from=VATSIMUK&packet=TEST',
+                    config('acars.hoppie.login_code')
+                )
+            );
+            $this->assertFalse($loggedMessage->successful);
+            return;
+        }
+
+        self::fail('Expected an AcarsRequestException but did not get one');
+    }
+
+    public function testItGetsOnlineCallsignsIfNotCached()
+    {
+        Http::fake(
+            [
+                config('acars.hoppie.url') => Http::sequence()
+                    ->push('ok {BAW123 BAW456}')
+                    ->push('ok')
+            ]
+        );
+
+        $this->mockTelex->shouldReceive('getTarget')->andReturn('BAW123');
+        $this->mockTelex->shouldReceive('getBody')->andReturn('TEST');
+        $this->provider->sendTelex($this->mockTelex);
+
+        Http::assertSent(function (Request $request) {
+            return $request->isForm() &&
+                $request->body() === sprintf(
+                    'logon=%s&type=ping&to=VATSIMUK&from=VATSIMUK&packet=ALL-CALLSIGNS',
+                    config('acars.hoppie.login_code')
+                );
+        });
+
+        Http::assertSent(function (Request $request) {
+            return $request->isForm() &&
+                $request->body() === sprintf(
+                    'logon=%s&type=telex&to=BAW123&from=VATSIMUK&packet=TEST',
+                    config('acars.hoppie.login_code')
+                );
+        });
+
+        $this->assertEquals(collect(['BAW123', 'BAW456']), Cache::get(self::CACHE_KEY));
+    }
+
+    public function testItDoesntSendATelexIfAircraftNotOnline()
+    {
+        Cache::set(self::CACHE_KEY, collect(['BAW456']), 300);
+        Http::fake();
+
+        $this->mockTelex->shouldReceive('getTarget')->andReturn('BAW123');
+        $this->mockTelex->shouldReceive('getBody')->andReturn('TEST');
+        $this->provider->sendTelex($this->mockTelex);
+
+        Http::assertNothingSent();
+    }
+
+    public function testItSendsATelex()
+    {
+        Cache::set(self::CACHE_KEY, collect(['BAW123', 'BAW456']), 300);
+        Http::fake(
+            [
+                config('acars.hoppie.url') => Http::response('ok'),
+            ]
+        );
+
+        $this->mockTelex->shouldReceive('getTarget')->andReturn('BAW123');
+        $this->mockTelex->shouldReceive('getBody')->andReturn('TEST');
+        $this->provider->sendTelex($this->mockTelex);
+
+        Http::assertSent(function (Request $request) {
+            return $request->isForm() &&
+                $request->body() === sprintf(
+                    'logon=%s&type=telex&to=BAW123&from=VATSIMUK&packet=TEST',
+                    config('acars.hoppie.login_code')
+                );
+        });
+    }
+}

--- a/tests/app/Filament/Pages/UserPreferencesTest.php
+++ b/tests/app/Filament/Pages/UserPreferencesTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use App\BaseFilamentTestCase;
+use Livewire\Livewire;
+
+class UserPreferencesTest extends BaseFilamentTestCase
+{
+    public function testItTogglesStandAcarsMessages()
+    {
+        Livewire::test(UserPreferences::class)
+            ->set('send_stand_acars_messages', true);
+
+        $this->assertDatabaseHas(
+            'user',
+            [
+                'id' => self::ACTIVE_USER_CID,
+                'send_stand_acars_messages' => 1,
+            ]
+        );
+
+        Livewire::test(UserPreferences::class)
+            ->set('send_stand_acars_messages', false);
+
+        $this->assertDatabaseHas(
+            'user',
+            [
+                'id' => self::ACTIVE_USER_CID,
+                'send_stand_acars_messages' => 0,
+            ]
+        );
+    }
+}

--- a/tests/app/Filament/Pages/UserPreferencesTest.php
+++ b/tests/app/Filament/Pages/UserPreferencesTest.php
@@ -31,4 +31,29 @@ class UserPreferencesTest extends BaseFilamentTestCase
             ]
         );
     }
+
+    public function testItTogglesStandAcarsMessagesAtUncontrolledAirfields()
+    {
+        Livewire::test(UserPreferences::class)
+            ->set('stand_acars_messages_uncontrolled_airfield', true);
+
+        $this->assertDatabaseHas(
+            'user',
+            [
+                'id' => self::ACTIVE_USER_CID,
+                'stand_acars_messages_uncontrolled_airfield' => 1,
+            ]
+        );
+
+        Livewire::test(UserPreferences::class)
+            ->set('stand_acars_messages_uncontrolled_airfield', false);
+
+        $this->assertDatabaseHas(
+            'user',
+            [
+                'id' => self::ACTIVE_USER_CID,
+                'stand_acars_messages_uncontrolled_airfield' => 0,
+            ]
+        );
+    }
 }

--- a/tests/app/Listeners/Stand/SendStandAllocationAcarsMessageTest.php
+++ b/tests/app/Listeners/Stand/SendStandAllocationAcarsMessageTest.php
@@ -12,6 +12,7 @@ use App\Models\Stand\StandAssignment;
 use App\Models\User\User;
 use App\Models\Vatsim\NetworkAircraft;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Event;
 use Mockery;
 
 class SendStandAllocationAcarsMessageTest extends BaseFunctionalTestCase
@@ -59,6 +60,12 @@ class SendStandAllocationAcarsMessageTest extends BaseFunctionalTestCase
         // Create handlers
         $this->event = new StandAssignedEvent($assignment);
         $this->handler = $this->app->make(SendStandAllocationAcarsMessage::class);
+    }
+
+    public function testItListensForEvents()
+    {
+        Event::fake();
+        Event::assertListening(StandAssignedEvent::class, SendStandAllocationAcarsMessage::class);
     }
 
     public function testItSendsAnAcarsMessage()

--- a/tests/app/Listeners/Stand/SendStandAllocationAcarsMessageTest.php
+++ b/tests/app/Listeners/Stand/SendStandAllocationAcarsMessageTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Listeners\Stand;
+
+use App\BaseFunctionalTestCase;
+use App\Events\StandAssignedEvent;
+use App\Models\Airfield\Airfield;
+use App\Models\Stand\Stand;
+use App\Models\Stand\StandAssignment;
+use App\Models\Vatsim\NetworkAircraft;
+
+class SendStandAllocationAcarsMessageTest extends BaseFunctionalTestCase
+{
+    private readonly StandAssignedEvent $event;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $airfield = Airfield::factory()->create([
+            'latitude' => 51.4775,
+            'longitude' => -0.461389,
+        ]);
+        $stand = Stand::factory()->create(['airfield_id' => $airfield->id]);
+        $aircraft = NetworkAircraft::factory()->create(
+            [
+                'planned_destairport' => $airfield->code,
+                'latitude' => 52.453889,
+                'longitude' => -1.748056,
+            ]
+        );
+        $assignment = StandAssignment::create(
+            [
+                'callsign' => $aircraft->callsign,
+                'stand_id' => $stand->id,
+            ]
+        );
+        $this->event = new StandAssignedEvent($assignment);
+    }
+
+    public function testItSendsAnAcarsMessage()
+    {
+    }
+}

--- a/tests/app/Listeners/Stand/SendStandAllocationAcarsMessageTest.php
+++ b/tests/app/Listeners/Stand/SendStandAllocationAcarsMessageTest.php
@@ -2,42 +2,111 @@
 
 namespace App\Listeners\Stand;
 
+use App\Acars\Message\Telex\StandAssignedTelexMessage;
+use App\Acars\Provider\AcarsProviderInterface;
 use App\BaseFunctionalTestCase;
 use App\Events\StandAssignedEvent;
 use App\Models\Airfield\Airfield;
 use App\Models\Stand\Stand;
 use App\Models\Stand\StandAssignment;
+use App\Models\User\User;
 use App\Models\Vatsim\NetworkAircraft;
+use Illuminate\Support\Facades\Config;
+use Mockery;
 
 class SendStandAllocationAcarsMessageTest extends BaseFunctionalTestCase
 {
+    private readonly AcarsProviderInterface $acarsProvider;
     private readonly StandAssignedEvent $event;
+    private readonly SendStandAllocationAcarsMessage $handler;
 
     public function setUp(): void
     {
         parent::setUp();
+        // Mock acars
+        $this->acarsProvider = Mockery::mock(AcarsProviderInterface::class);
+        $this->app->instance(AcarsProviderInterface::class, $this->acarsProvider);
+
+        // Ensure sending messages is turned on
+        Config::set('stands.assignment_acars_message', true);
+
+        // Create airfield and stand
         $airfield = Airfield::factory()->create([
-            'latitude' => 51.4775,
+            'latitude' => 51.4775, // Heathrow
             'longitude' => -0.461389,
         ]);
         $stand = Stand::factory()->create(['airfield_id' => $airfield->id]);
+
+        // Create aircraft and user
+        $user = User::factory()->create(['send_stand_acars_messages' => true]);
         $aircraft = NetworkAircraft::factory()->create(
             [
+                'cid' => $user->id,
                 'planned_destairport' => $airfield->code,
-                'latitude' => 52.453889,
+                'latitude' => 52.453889, // Over Birmingham
                 'longitude' => -1.748056,
             ]
         );
+
+        // Assign aircraft to stand
         $assignment = StandAssignment::create(
             [
                 'callsign' => $aircraft->callsign,
                 'stand_id' => $stand->id,
             ]
         );
+
+        // Create handlers
         $this->event = new StandAssignedEvent($assignment);
+        $this->handler = $this->app->make(SendStandAllocationAcarsMessage::class);
     }
 
     public function testItSendsAnAcarsMessage()
     {
+        $this->acarsProvider->shouldReceive('sendTelex')
+            ->with(
+                Mockery::on(
+                    fn(StandAssignedTelexMessage $message) => $message->getTarget(
+                        ) === $this->event->getStandAssignment()->callsign
+                )
+            )->once();
+
+        $this->handler->handle($this->event);
+    }
+
+    public function testItDoesntSendAcarsMessageIfStandIsNotAtArrivalAirport()
+    {
+        $this->event->getStandAssignment()->aircraft->planned_destairport = '1234';
+        $this->acarsProvider->shouldReceive('sendTelex')->never();
+        $this->handler->handle($this->event);
+    }
+
+    public function testItDoesntSendAcarsMessageIfAircraftIsArrivingAtItsDepartureAirport()
+    {
+        $this->event->getStandAssignment()->aircraft->planned_depairport = $this->event->getStandAssignment()->aircraft->planned_destairport;
+        $this->acarsProvider->shouldReceive('sendTelex')->never();
+        $this->handler->handle($this->event);
+    }
+
+    public function testItDoesntSendAcarsMessageIfAircraftIsTooCloseToItsArrivalAirport()
+    {
+        $this->event->getStandAssignment()->aircraft->latitude = 51.4775;
+        $this->event->getStandAssignment()->aircraft->longitude = -0.461389;
+        $this->acarsProvider->shouldReceive('sendTelex')->never();
+        $this->handler->handle($this->event);
+    }
+
+    public function testItDoesntSendAcarsMessageIfUserHasntPermittedIt()
+    {
+        $this->event->getStandAssignment()->aircraft->user->send_stand_acars_messages = false;
+        $this->acarsProvider->shouldReceive('sendTelex')->never();
+        $this->handler->handle($this->event);
+    }
+
+    public function testItDoesntSendAcarsMessageIfSystemTurnedOff()
+    {
+        Config::set('stands.assignment_acars_message', false);
+        $this->acarsProvider->shouldReceive('sendTelex')->never();
+        $this->handler->handle($this->event);
     }
 }

--- a/tests/app/Listeners/Stand/SendStandAllocationAcarsMessageTest.php
+++ b/tests/app/Listeners/Stand/SendStandAllocationAcarsMessageTest.php
@@ -103,6 +103,20 @@ class SendStandAllocationAcarsMessageTest extends BaseFunctionalTestCase
         $this->handler->handle($this->event);
     }
 
+    public function testItDoesntSendAcarsMessageIfAircraftHasNoLatitudeWhichIndicatesItsOnSweatbox()
+    {
+        $this->event->getStandAssignment()->aircraft->latitude = null;
+        $this->acarsProvider->shouldReceive('sendTelex')->never();
+        $this->handler->handle($this->event);
+    }
+
+    public function testItDoesntSendAcarsMessageIfAircraftHasNoLongitudeWhichIndicatesItsOnSweatbox()
+    {
+        $this->event->getStandAssignment()->aircraft->longitude = null;
+        $this->acarsProvider->shouldReceive('sendTelex')->never();
+        $this->handler->handle($this->event);
+    }
+
     public function testItDoesntSendAcarsMessageIfUserHasntPermittedIt()
     {
         $this->event->getStandAssignment()->aircraft->user->send_stand_acars_messages = false;

--- a/tests/app/Models/Acars/AcarsMessageTest.php
+++ b/tests/app/Models/Acars/AcarsMessageTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Models\Acars;
+
+use App\BaseFunctionalTestCase;
+use Carbon\Carbon;
+
+class AcarsMessageTest extends BaseFunctionalTestCase
+{
+    public function testItPrunes()
+    {
+        // Should be deleted, far too old
+        $message1 = AcarsMessage::create(
+            [
+                'message' => '1',
+                'successful' => true,
+            ]
+        );
+        $message1->created_at = Carbon::now()->subMonths(2);
+        $message1->save();
+
+        // Should be deleted, just too old
+        $message2 = AcarsMessage::create(
+            [
+                'message' => '1',
+                'successful' => true,
+            ]
+        );
+        $message2->created_at = Carbon::now()->subMonth()->subMinute();
+        $message2->save();
+
+        // Should be kept, not quite old enough
+        $message3 = AcarsMessage::create(
+            [
+                'message' => '1',
+                'successful' => true,
+            ]
+        );
+        $message3->created_at = Carbon::now()->subMonth()->addMinute();
+        $message3->save();
+
+        // Should be kept, very recent
+        $message4 = AcarsMessage::create(
+            [
+                'message' => '1',
+                'successful' => true,
+            ]
+        );
+
+        // Prune
+        $message1->prunable()->delete();
+        $this->assertDatabaseCount('acars_messages', 2);
+        $this->assertDatabaseHas(
+            'acars_messages',
+            [
+                'id' => $message3->id,
+            ]
+        );
+        $this->assertDatabaseHas(
+            'acars_messages',
+            [
+                'id' => $message4->id,
+            ]
+        );
+        $this->assertDatabaseMissing(
+            'acars_messages',
+            [
+                'id' => $message2->id,
+            ]
+        );
+        $this->assertDatabaseMissing(
+            'acars_messages',
+            [
+                'id' => $message1->id,
+            ]
+        );
+    }
+}


### PR DESCRIPTION
- This PR supersedes https://github.com/VATSIM-UK/uk-controller-api/pull/633, as the previous was too-far gone and things have changed a lot since, though borrows a lot of the ideas.
- Adds ACARS helper classes to send messages over the HOPPIE system.
- Adds a user preferences page to indicate if they would like ACARS messages.
- Adds a listener for stand assignment events.
- If the stand assignment is at the aircrafts arrival airport, and the aircraft is > 7.5nm from the airport, then we'll try to send a message to them.

Resolve #344 