### PR TITLE
fix: acars messages not received in some clients

### DIFF
--- a/app/Acars/Message/Telex/StandAssignedTelexMessage.php
+++ b/app/Acars/Message/Telex/StandAssignedTelexMessage.php
@@ -21,9 +21,7 @@ class StandAssignedTelexMessage implements TelexMessageInterface
     public function getBody(): string
     {
         return sprintf(
-            "You have been provisionally assigned stand %s.\n\n" .
-            "Safe landings.\n\n" .
-            "VATSIM UK",
+            'You have been provisionally assigned stand %s. Safe landings. VATSIM UK.',
             $this->getStandAssignmentString()
         );
     }

--- a/tests/app/Acars/Message/Telex/StandAssignedTelexMessageTest.php
+++ b/tests/app/Acars/Message/Telex/StandAssignedTelexMessageTest.php
@@ -30,15 +30,7 @@ class StandAssignedTelexMessageTest extends BaseFunctionalTestCase
 
     public function testItHasAMessage()
     {
-        $expected = <<<END
-You have been provisionally assigned stand EGLL/251.
-
-Safe landings.
-
-VATSIM UK
-END;
-
-        $expected = Str::replace("\r\n", "\n", $expected);
+        $expected = 'You have been provisionally assigned stand EGLL/251. Safe landings. VATSIM UK.';
         $this->assertEquals($expected, $this->message->getBody());
     }
 }


### PR DESCRIPTION
Removes the newlines in the stand telex message as this was not being displayed properly or not being received in some ACARS clients.

Fixes #1317