### PR TITLE
Stand assignment context

### DIFF
--- a/app/Filament/Resources/StandAssignmentsHistoryResource.php
+++ b/app/Filament/Resources/StandAssignmentsHistoryResource.php
@@ -49,7 +49,8 @@ class StandAssignmentsHistoryResource extends Resource
                     ->searchable(),
                 TextColumn::make('identifier')
                     ->getStateUsing(fn(StandAssignmentsHistory $record) => $record->stand->airfieldIdentifier)
-                    ->label(static::translateTablePath('columns.identifier')),
+                    ->label(static::translateTablePath('columns.identifier'))
+                    ->searchable(),
                 TextColumn::make('assigned_at')
                     ->label(static::translateTablePath('columns.assigned_at'))
                     ->dateTime(),
@@ -61,7 +62,7 @@ class StandAssignmentsHistoryResource extends Resource
                     ->label(static::translateTablePath('columns.type')),
             ])
             ->actions([
-                ViewAction::make()
+                ViewAction::make('view_context')
                     ->label('View Context'),
             ])
             ->filters([

--- a/app/Filament/Resources/StandAssignmentsHistoryResource.php
+++ b/app/Filament/Resources/StandAssignmentsHistoryResource.php
@@ -4,12 +4,14 @@ namespace App\Filament\Resources;
 
 use App\Filament\Resources\StandAssignmentsHistoryResource\Pages;
 use App\Models\Stand\StandAssignmentsHistory;
+use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\ViewField;
 use Filament\Resources\Form;
 use Filament\Resources\Resource;
 use Filament\Resources\Table;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\Filter;
 use Illuminate\Database\Eloquent\Builder;
 
 class StandAssignmentsHistoryResource extends Resource
@@ -66,7 +68,13 @@ class StandAssignmentsHistoryResource extends Resource
                     ->label('View Context'),
             ])
             ->filters([
-                //
+                Filter::make('callsign')
+                    ->formComponent(TextInput::class)
+                    ->query(
+                        fn(Builder $query, array $data) => isset($data['isActive'])
+                        ? $query->where('callsign', $data['isActive'])
+                        : $query
+                    ),
             ]);
     }
 

--- a/app/Filament/Resources/StandAssignmentsHistoryResource.php
+++ b/app/Filament/Resources/StandAssignmentsHistoryResource.php
@@ -2,8 +2,10 @@
 
 namespace App\Filament\Resources;
 
+use App\Filament\Helpers\SelectOptions;
 use App\Filament\Resources\StandAssignmentsHistoryResource\Pages;
 use App\Models\Stand\StandAssignmentsHistory;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\ViewField;
 use Filament\Resources\Form;
@@ -12,6 +14,7 @@ use Filament\Resources\Table;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\Filter;
+use Filament\Tables\Filters\SelectFilter;
 use Illuminate\Database\Eloquent\Builder;
 
 class StandAssignmentsHistoryResource extends Resource
@@ -73,6 +76,13 @@ class StandAssignmentsHistoryResource extends Resource
                     ->query(
                         fn(Builder $query, array $data) => isset($data['isActive'])
                         ? $query->where('callsign', $data['isActive'])
+                        : $query
+                    ),
+                SelectFilter::make('airfield')
+                    ->options(SelectOptions::airfields())
+                    ->query(
+                        fn(Builder $query, array $data) => isset($data['value'])
+                        ? $query->whereHas('stand.airfield', fn(Builder $query) => $query->where('id', $data['value']))
                         : $query
                     ),
             ]);

--- a/app/Filament/Resources/StandAssignmentsHistoryResource.php
+++ b/app/Filament/Resources/StandAssignmentsHistoryResource.php
@@ -71,7 +71,8 @@ class StandAssignmentsHistoryResource extends Resource
             ])
             ->actions([
                 ViewAction::make('view_context')
-                    ->label('View Context'),
+                    ->label('View Context')
+                    ->hidden(fn(StandAssignmentsHistory $record) => is_null($record->context) || empty($record->context)),
             ])
             ->filters([
                 Filter::make('callsign')

--- a/app/Filament/Resources/StandAssignmentsHistoryResource.php
+++ b/app/Filament/Resources/StandAssignmentsHistoryResource.php
@@ -104,7 +104,9 @@ class StandAssignmentsHistoryResource extends Resource
             ->actions([
                 ViewAction::make('view_context')
                     ->label('View Context')
-                    ->hidden(fn (StandAssignmentsHistory $record) => is_null($record->context) || empty($record->context)),
+                    ->hidden(
+                        fn (StandAssignmentsHistory $record) => is_null($record->context) || empty($record->context)
+                    ),
             ])
             ->filters([
                 Filter::make('callsign')
@@ -122,7 +124,9 @@ class StandAssignmentsHistoryResource extends Resource
                             ->searchable()
                             ->label('Airfield'),
                         Select::make('stand')
-                            ->options(fn (Closure $get) => SelectOptions::standsForAirfield(Airfield::find($get('airfield'))))
+                            ->options(
+                                fn (Closure $get) => SelectOptions::standsForAirfield(Airfield::find($get('airfield')))
+                            )
                             ->searchable()
                             ->label('Stand')
                             ->hidden(fn (Closure $get) => !$get('airfield')),
@@ -140,7 +144,10 @@ class StandAssignmentsHistoryResource extends Resource
                     })
                     ->query(function (Builder $query, array $data) {
                         if (isset($data['airfield'])) {
-                            $query->whereHas('stand.airfield', fn (Builder $query) => $query->where('id', $data['airfield']));
+                            $query->whereHas(
+                                'stand.airfield',
+                                fn (Builder $query) => $query->where('id', $data['airfield'])
+                            );
                         }
 
                         if (isset($data['stand'])) {

--- a/app/Filament/Resources/StandAssignmentsHistoryResource.php
+++ b/app/Filament/Resources/StandAssignmentsHistoryResource.php
@@ -88,7 +88,7 @@ class StandAssignmentsHistoryResource extends Resource
                     ->label(static::translateTablePath('columns.callsign'))
                     ->searchable(),
                 TextColumn::make('identifier')
-                    ->getStateUsing(fn(StandAssignmentsHistory $record) => $record->stand->airfieldIdentifier)
+                    ->getStateUsing(fn (StandAssignmentsHistory $record) => $record->stand->airfieldIdentifier)
                     ->label(static::translateTablePath('columns.identifier'))
                     ->searchable(),
                 TextColumn::make('assigned_at')
@@ -104,13 +104,13 @@ class StandAssignmentsHistoryResource extends Resource
             ->actions([
                 ViewAction::make('view_context')
                     ->label('View Context')
-                    ->hidden(fn(StandAssignmentsHistory $record) => is_null($record->context) || empty($record->context)),
+                    ->hidden(fn (StandAssignmentsHistory $record) => is_null($record->context) || empty($record->context)),
             ])
             ->filters([
                 Filter::make('callsign')
                     ->formComponent(TextInput::class)
                     ->query(
-                        fn(Builder $query, array $data) => isset($data['isActive'])
+                        fn (Builder $query, array $data) => isset($data['isActive'])
                         ? $query->where('callsign', $data['isActive'])
                         : $query
                     ),
@@ -122,13 +122,12 @@ class StandAssignmentsHistoryResource extends Resource
                             ->searchable()
                             ->label('Airfield'),
                         Select::make('stand')
-                            ->options(fn(Closure $get) => SelectOptions::standsForAirfield(Airfield::find($get('airfield'))))
+                            ->options(fn (Closure $get) => SelectOptions::standsForAirfield(Airfield::find($get('airfield'))))
                             ->searchable()
                             ->label('Stand')
-                            ->hidden(fn(Closure $get) => !$get('airfield')),
+                            ->hidden(fn (Closure $get) => !$get('airfield')),
                     ])
-                    ->indicateUsing(function (array $data)
-                    {
+                    ->indicateUsing(function (array $data) {
                         if (isset($data['stand'])) {
                             return 'Stand: ' . Stand::find($data['stand'])->airfieldIdentifier;
                         }
@@ -139,10 +138,9 @@ class StandAssignmentsHistoryResource extends Resource
 
                         return null;
                     })
-                    ->query(function (Builder $query, array $data)
-                    {
+                    ->query(function (Builder $query, array $data) {
                         if (isset($data['airfield'])) {
-                            $query->whereHas('stand.airfield', fn(Builder $query) => $query->where('id', $data['airfield']));
+                            $query->whereHas('stand.airfield', fn (Builder $query) => $query->where('id', $data['airfield']));
                         }
 
                         if (isset($data['stand'])) {

--- a/app/Filament/Resources/StandAssignmentsHistoryResource.php
+++ b/app/Filament/Resources/StandAssignmentsHistoryResource.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\StandAssignmentsHistoryResource\Pages;
+use App\Models\Stand\StandAssignmentsHistory;
+use Filament\Forms\Components\ViewField;
+use Filament\Resources\Form;
+use Filament\Resources\Resource;
+use Filament\Resources\Table;
+use Filament\Tables\Actions\ViewAction;
+use Filament\Tables\Columns\TextColumn;
+use Illuminate\Database\Eloquent\Builder;
+
+class StandAssignmentsHistoryResource extends Resource
+{
+    use TranslatesStrings;
+
+    protected static ?string $model = StandAssignmentsHistory::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-collection';
+    protected static ?string $navigationLabel = 'Stand Assignment History';
+    protected static ?string $label = 'Stand Assignment History';
+
+    protected static ?string $navigationGroup = 'Airfield';
+
+    public static function getEloquentQuery(): Builder
+    {
+        return StandAssignmentsHistory::with('stand', 'stand.airfield');
+    }
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->disabled()
+            ->schema([
+                ViewField::make('context')
+                    ->view('filament.forms.stand_assignment_history_context')
+                    ->label(static::translateFormPath('columns.context')),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('callsign')
+                    ->label(static::translateTablePath('columns.callsign'))
+                    ->searchable(),
+                TextColumn::make('identifier')
+                    ->getStateUsing(fn(StandAssignmentsHistory $record) => $record->stand->airfieldIdentifier)
+                    ->label(static::translateTablePath('columns.identifier')),
+                TextColumn::make('assigned_at')
+                    ->label(static::translateTablePath('columns.assigned_at'))
+                    ->dateTime(),
+                TextColumn::make('deleted_at')
+                    ->placeholder('--')
+                    ->label(static::translateTablePath('columns.deleted_at'))
+                    ->dateTime(),
+                TextColumn::make('type')
+                    ->label(static::translateTablePath('columns.type')),
+            ])
+            ->actions([
+                ViewAction::make()
+                    ->label('View Context'),
+            ])
+            ->filters([
+                //
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListStandAssignmentsHistories::route('/'),
+            'view' => Pages\ViewAssignmentContext::route('/{record}'),
+        ];
+    }
+
+    protected static function translationPathRoot(): string
+    {
+        return 'stand_assignments_history';
+    }
+}

--- a/app/Filament/Resources/StandAssignmentsHistoryResource.php
+++ b/app/Filament/Resources/StandAssignmentsHistoryResource.php
@@ -43,6 +43,7 @@ class StandAssignmentsHistoryResource extends Resource
             ->disabled()
             ->schema([
                 ViewField::make('context')
+                    ->columnSpanFull()
                     ->view('filament.forms.stand_assignment_history_context')
                     ->label(static::translateFormPath('columns.context')),
             ]);

--- a/app/Filament/Resources/StandAssignmentsHistoryResource/Pages/ListStandAssignmentsHistories.php
+++ b/app/Filament/Resources/StandAssignmentsHistoryResource/Pages/ListStandAssignmentsHistories.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Filament\Resources\StandAssignmentsHistoryResource\Pages;
+
+use App\Filament\Resources\Pages\LimitsTableRecordListingOptions;
+use App\Filament\Resources\StandAssignmentsHistoryResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListStandAssignmentsHistories extends ListRecords
+{
+    use LimitsTableRecordListingOptions;
+
+    protected static string $resource = StandAssignmentsHistoryResource::class;
+}

--- a/app/Filament/Resources/StandAssignmentsHistoryResource/Pages/ViewAssignmentContext.php
+++ b/app/Filament/Resources/StandAssignmentsHistoryResource/Pages/ViewAssignmentContext.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\StandAssignmentsHistoryResource\Pages;
+
+use App\Filament\Resources\StandAssignmentsHistoryResource;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewAssignmentContext extends ViewRecord
+{
+    protected static string $resource = StandAssignmentsHistoryResource::class;
+}

--- a/app/Http/Controllers/StandController.php
+++ b/app/Http/Controllers/StandController.php
@@ -81,7 +81,8 @@ class StandController extends BaseController
         try {
             $this->assignmentsService->createStandAssignment(
                 $request->json('callsign'),
-                (int)$request->json('stand_id')
+                (int)$request->json('stand_id'),
+                'User'
             );
             return response()->json([], 201);
         } catch (StandNotFoundException) {

--- a/app/Models/Stand/StandAssignmentsHistory.php
+++ b/app/Models/Stand/StandAssignmentsHistory.php
@@ -26,4 +26,9 @@ class StandAssignmentsHistory extends Model
     protected $casts = [
         'context' => 'array',
     ];
+
+    public function stand()
+    {
+        return $this->belongsTo(Stand::class);
+    }
 }

--- a/app/Models/Stand/StandAssignmentsHistory.php
+++ b/app/Models/Stand/StandAssignmentsHistory.php
@@ -18,6 +18,12 @@ class StandAssignmentsHistory extends Model
     protected $fillable = [
         'callsign',
         'stand_id',
-        'user_id'
+        'user_id',
+        'type',
+        'context',
+    ];
+
+    protected $casts = [
+        'context' => 'array',
     ];
 }

--- a/app/Policies/ChecksUserRoles.php
+++ b/app/Policies/ChecksUserRoles.php
@@ -6,7 +6,17 @@ use App\Models\User\User;
 
 trait ChecksUserRoles
 {
+    private function userHasAnyRole(User $user): bool
+    {
+        return $user->roles()->count() > 0;
+    }
+
     private function userHasRole(User $user, array $roles): bool
+    {
+        return self::checkUserHasRole($user, $roles);
+    }
+
+    private static function checkUserHasRole(User $user, array $roles): bool
     {
         foreach ($user->roles as $role) {
             if ($role->isOneOf($roles)) {

--- a/app/Policies/ReadOnlyPolicy.php
+++ b/app/Policies/ReadOnlyPolicy.php
@@ -2,7 +2,6 @@
 
 namespace App\Policies;
 
-use App\Models\User\User;
 use Illuminate\Auth\Access\HandlesAuthorization;
 
 /**
@@ -11,6 +10,7 @@ use Illuminate\Auth\Access\HandlesAuthorization;
 class ReadOnlyPolicy
 {
     use HandlesAuthorization;
+    use RejectsNonReadOnlyActions;
 
     public function view(): bool
     {
@@ -20,75 +20,5 @@ class ReadOnlyPolicy
     public function viewAny(): bool
     {
         return true;
-    }
-
-    public function attach(): bool
-    {
-        return false;
-    }
-
-    public function detach(): bool
-    {
-        return false;
-    }
-
-    public function update(): bool
-    {
-        return false;
-    }
-
-    public function create(): bool
-    {
-        return false;
-    }
-
-    public function delete(): bool
-    {
-        return false;
-    }
-
-    public function restore(): bool
-    {
-        return false;
-    }
-
-    public function forceDelete(): bool
-    {
-        return false;
-    }
-
-    public function detachAny(): bool
-    {
-        return false;
-    }
-
-    public function dissociate(): bool
-    {
-        return false;
-    }
-
-    public function dissociateAny(): bool
-    {
-        return false;
-    }
-
-    public function replicate(): bool
-    {
-        return false;
-    }
-
-    public function restoreAny(): bool
-    {
-        return false;
-    }
-
-    public function deleteAny(): bool
-    {
-        return false;
-    }
-
-    public function forceDeleteAny(): bool
-    {
-        return false;
     }
 }

--- a/app/Policies/ReadOnlyWithRolePolicy.php
+++ b/app/Policies/ReadOnlyWithRolePolicy.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Policies;
+
+use Illuminate\Auth\Access\HandlesAuthorization;
+use App\Models\User\User;
+
+/**
+ * Policy that allows read only access only to users with a role.
+ */
+class ReadOnlyWithRolePolicy
+{
+    use HandlesAuthorization;
+    use ChecksUserRoles;
+
+    public function view(?User $user): bool
+    {
+        return $this->userHasAnyRole($user);
+    }
+
+    public function viewAny(?User $user): bool
+    {
+        return $this->userHasAnyRole($user);
+    }
+
+    public function attach(): bool
+    {
+        return false;
+    }
+
+    public function detach(): bool
+    {
+        return false;
+    }
+
+    public function update(): bool
+    {
+        return false;
+    }
+
+    public function create(): bool
+    {
+        return false;
+    }
+
+    public function delete(): bool
+    {
+        return false;
+    }
+
+    public function restore(): bool
+    {
+        return false;
+    }
+
+    public function forceDelete(): bool
+    {
+        return false;
+    }
+
+    public function detachAny(): bool
+    {
+        return false;
+    }
+
+    public function dissociate(): bool
+    {
+        return false;
+    }
+
+    public function dissociateAny(): bool
+    {
+        return false;
+    }
+
+    public function replicate(): bool
+    {
+        return false;
+    }
+
+    public function restoreAny(): bool
+    {
+        return false;
+    }
+
+    public function deleteAny(): bool
+    {
+        return false;
+    }
+
+    public function forceDeleteAny(): bool
+    {
+        return false;
+    }
+}

--- a/app/Policies/ReadOnlyWithRolePolicy.php
+++ b/app/Policies/ReadOnlyWithRolePolicy.php
@@ -8,7 +8,7 @@ use App\Models\User\User;
 /**
  * Policy that allows read only access only to users with a role.
  */
-class ReadOnlyWithRolePolicy
+class ReadOnlyWithRolePolicy extends ReadOnlyPolicy
 {
     use HandlesAuthorization;
     use ChecksUserRoles;
@@ -21,75 +21,5 @@ class ReadOnlyWithRolePolicy
     public function viewAny(?User $user): bool
     {
         return $this->userHasAnyRole($user);
-    }
-
-    public function attach(): bool
-    {
-        return false;
-    }
-
-    public function detach(): bool
-    {
-        return false;
-    }
-
-    public function update(): bool
-    {
-        return false;
-    }
-
-    public function create(): bool
-    {
-        return false;
-    }
-
-    public function delete(): bool
-    {
-        return false;
-    }
-
-    public function restore(): bool
-    {
-        return false;
-    }
-
-    public function forceDelete(): bool
-    {
-        return false;
-    }
-
-    public function detachAny(): bool
-    {
-        return false;
-    }
-
-    public function dissociate(): bool
-    {
-        return false;
-    }
-
-    public function dissociateAny(): bool
-    {
-        return false;
-    }
-
-    public function replicate(): bool
-    {
-        return false;
-    }
-
-    public function restoreAny(): bool
-    {
-        return false;
-    }
-
-    public function deleteAny(): bool
-    {
-        return false;
-    }
-
-    public function forceDeleteAny(): bool
-    {
-        return false;
     }
 }

--- a/app/Policies/ReadOnlyWithRolePolicy.php
+++ b/app/Policies/ReadOnlyWithRolePolicy.php
@@ -8,10 +8,11 @@ use App\Models\User\User;
 /**
  * Policy that allows read only access only to users with a role.
  */
-class ReadOnlyWithRolePolicy extends ReadOnlyPolicy
+class ReadOnlyWithRolePolicy
 {
     use HandlesAuthorization;
     use ChecksUserRoles;
+    use RejectsNonReadOnlyActions;
 
     public function view(?User $user): bool
     {

--- a/app/Policies/RejectsNonReadOnlyActions.php
+++ b/app/Policies/RejectsNonReadOnlyActions.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Policies;
+
+trait RejectsNonReadOnlyActions
+{
+    public function attach(): bool
+    {
+        return false;
+    }
+
+    public function detach(): bool
+    {
+        return false;
+    }
+
+    public function update(): bool
+    {
+        return false;
+    }
+
+    public function create(): bool
+    {
+        return false;
+    }
+
+    public function delete(): bool
+    {
+        return false;
+    }
+
+    public function restore(): bool
+    {
+        return false;
+    }
+
+    public function forceDelete(): bool
+    {
+        return false;
+    }
+
+    public function detachAny(): bool
+    {
+        return false;
+    }
+
+    public function dissociate(): bool
+    {
+        return false;
+    }
+
+    public function dissociateAny(): bool
+    {
+        return false;
+    }
+
+    public function replicate(): bool
+    {
+        return false;
+    }
+
+    public function restoreAny(): bool
+    {
+        return false;
+    }
+
+    public function deleteAny(): bool
+    {
+        return false;
+    }
+
+    public function forceDeleteAny(): bool
+    {
+        return false;
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -38,6 +38,7 @@ use App\Policies\OperationsContributorPolicy;
 use App\Policies\PluginEditableDataPolicy;
 use App\Policies\PluginVersionPolicy;
 use App\Policies\ReadOnlyPolicy;
+use App\Policies\ReadOnlyWithRolePolicy;
 use App\Policies\UserPolicy;
 use App\Services\UserConfigCreatorInterface;
 use App\Services\UserConfigService;
@@ -63,8 +64,9 @@ class AuthServiceProvider extends ServiceProvider
         self::SCOPE_DATA_ADMIN => 'Can administer live data stored in the system',
     ];
 
+    // These policies are used by filament to determine resource and action access.
     protected $policies = [
-        // The defaults
+            // The defaults
         Aircraft::class => OperationsContributorPolicy::class,
         Airfield::class => DefaultFilamentPolicy::class,
         AirfieldPairingSquawkRange::class => DefaultFilamentPolicy::class,
@@ -89,16 +91,18 @@ class AuthServiceProvider extends ServiceProvider
         UnitDiscreteSquawkRangeGuest::class => DefaultFilamentPolicy::class,
         WakeCategory::class => OperationsContributorPolicy::class,
 
-        // Things the plugin can assign
+            // Things the plugin can assign
         SquawkAssignment::class => PluginEditableDataPolicy::class,
-        StandAssignmentsHistory::class => PluginEditableDataPolicy::class,
 
-        // Things that can only be updated by external processes
+            // Things that can only be updated by external processes
         SrdNote::class => ReadOnlyPolicy::class,
         SrdRoute::class => ReadOnlyPolicy::class,
         Dependency::class => ReadOnlyPolicy::class,
 
-        // Special policies
+            // Things that can only be viewed by users with a role
+        StandAssignmentsHistory::class => ReadOnlyWithRolePolicy::class,
+
+            // Special policies
         Activity::class => ActivityLogPolicy::class,
         User::class => UserPolicy::class,
         Version::class => PluginVersionPolicy::class,

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -29,6 +29,7 @@ use App\Models\Squawk\UnitDiscrete\UnitDiscreteSquawkRangeGuest;
 use App\Models\Srd\SrdNote;
 use App\Models\Srd\SrdRoute;
 use App\Models\Stand\Stand;
+use App\Models\Stand\StandAssignmentsHistory;
 use App\Models\User\User;
 use App\Models\Version\Version;
 use App\Policies\ActivityLogPolicy;
@@ -90,6 +91,7 @@ class AuthServiceProvider extends ServiceProvider
 
         // Things the plugin can assign
         SquawkAssignment::class => PluginEditableDataPolicy::class,
+        StandAssignmentsHistory::class => PluginEditableDataPolicy::class,
 
         // Things that can only be updated by external processes
         SrdNote::class => ReadOnlyPolicy::class,

--- a/app/Providers/StandServiceProvider.php
+++ b/app/Providers/StandServiceProvider.php
@@ -15,6 +15,8 @@ use App\Allocator\Stand\CidReservedArrivalStandAllocator;
 use App\Allocator\Stand\UserRequestedArrivalStandAllocator;
 use App\Services\Stand\AirfieldStandService;
 use App\Services\Stand\ArrivalAllocationService;
+use App\Services\Stand\RecordsAssignmentHistory;
+use App\Services\Stand\StandAssignmentsHistoryService;
 use App\Services\Stand\StandAssignmentsService;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
@@ -35,7 +37,8 @@ class StandServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton(ArrivalAllocationService::class, function (Application $application) {
+        $this->app->singleton(ArrivalAllocationService::class, function (Application $application)
+        {
             return new ArrivalAllocationService(
                 $application->make(StandAssignmentsService::class),
                 [
@@ -63,5 +66,9 @@ class StandServiceProvider extends ServiceProvider
         });
         $this->app->singleton(StandReservationsImport::class);
         $this->app->singleton(AirfieldStandService::class);
+        $this->app->singleton(
+            RecordsAssignmentHistory::class,
+            fn(Application $application) => $application->make(StandAssignmentsHistoryService::class)
+        );
     }
 }

--- a/app/Providers/StandServiceProvider.php
+++ b/app/Providers/StandServiceProvider.php
@@ -37,8 +37,7 @@ class StandServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton(ArrivalAllocationService::class, function (Application $application)
-        {
+        $this->app->singleton(ArrivalAllocationService::class, function (Application $application) {
             return new ArrivalAllocationService(
                 $application->make(StandAssignmentsService::class),
                 [
@@ -68,7 +67,7 @@ class StandServiceProvider extends ServiceProvider
         $this->app->singleton(AirfieldStandService::class);
         $this->app->singleton(
             RecordsAssignmentHistory::class,
-            fn(Application $application) => $application->make(StandAssignmentsHistoryService::class)
+            fn (Application $application) => $application->make(StandAssignmentsHistoryService::class)
         );
     }
 }

--- a/app/Services/Stand/ArrivalAllocationService.php
+++ b/app/Services/Stand/ArrivalAllocationService.php
@@ -59,7 +59,7 @@ class ArrivalAllocationService
             ->each(function (NetworkAircraft $aircraft) {
                 foreach ($this->allocators as $allocator) {
                     if ($allocation = $allocator->allocate($aircraft)) {
-                        $this->assignmentsService->createStandAssignment($aircraft->callsign, $allocation);
+                        $this->assignmentsService->createStandAssignment($aircraft->callsign, $allocation, get_class($allocator));
                         return;
                     }
                 }

--- a/app/Services/Stand/ArrivalAllocationService.php
+++ b/app/Services/Stand/ArrivalAllocationService.php
@@ -59,7 +59,11 @@ class ArrivalAllocationService
             ->each(function (NetworkAircraft $aircraft) {
                 foreach ($this->allocators as $allocator) {
                     if ($allocation = $allocator->allocate($aircraft)) {
-                        $this->assignmentsService->createStandAssignment($aircraft->callsign, $allocation, get_class($allocator));
+                        $this->assignmentsService->createStandAssignment(
+                            $aircraft->callsign,
+                            $allocation,
+                            get_class($allocator)
+                        );
                         return;
                     }
                 }

--- a/app/Services/Stand/DepartureAllocationService.php
+++ b/app/Services/Stand/DepartureAllocationService.php
@@ -27,7 +27,7 @@ class DepartureAllocationService
         });
 
         $this->getDepartureStandsToAssign()->each(function (NetworkAircraft $aircraft) {
-            $this->assignmentsService->createStandAssignment($aircraft->callsign, $aircraft->stand_id);
+            $this->assignmentsService->createStandAssignment($aircraft->callsign, $aircraft->stand_id, 'Departure');
         });
     }
 

--- a/app/Services/Stand/RecordsAssignmentHistory.php
+++ b/app/Services/Stand/RecordsAssignmentHistory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Services\Stand;
+
+use App\Models\Stand\StandAssignment;
+
+interface RecordsAssignmentHistory
+{
+
+    /**
+     * Deletes any history items for the given assignment.
+     */
+    public function deleteHistoryFor(StandAssignment $target): void;
+
+    /**
+     * Creates a history item for the given assignment, along with some context about the assignment.
+     */
+    public function createHistoryItem(StandAssignmentContext $context): void;
+}

--- a/app/Services/Stand/RecordsAssignmentHistory.php
+++ b/app/Services/Stand/RecordsAssignmentHistory.php
@@ -6,7 +6,6 @@ use App\Models\Stand\StandAssignment;
 
 interface RecordsAssignmentHistory
 {
-
     /**
      * Deletes any history items for the given assignment.
      */

--- a/app/Services/Stand/StandAssignmentContext.php
+++ b/app/Services/Stand/StandAssignmentContext.php
@@ -7,31 +7,10 @@ use Illuminate\Support\Collection;
 
 class StandAssignmentContext
 {
-    private readonly StandAssignment $assignment;
-
-    private readonly string $assignmentType;
-
-    private readonly Collection $removedAssignments;
-
-    public function __construct(StandAssignment $assignment, string $assignmentType, Collection $removedAssignments)
-    {
-        $this->assignment = $assignment;
-        $this->assignmentType = $assignmentType;
-        $this->removedAssignments = $removedAssignments;
-    }
-
-    public function assignment(): StandAssignment
-    {
-        return $this->assignment;
-    }
-
-    public function assignmentType(): string
-    {
-        return $this->assignmentType;
-    }
-
-    public function removedAssignments(): Collection
-    {
-        return $this->removedAssignments;
+    public function __construct(
+        public readonly StandAssignment $assignment,
+        public readonly string $assignmentType,
+        public readonly Collection $removedAssignments
+    ) {
     }
 }

--- a/app/Services/Stand/StandAssignmentContext.php
+++ b/app/Services/Stand/StandAssignmentContext.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Services\Stand;
+
+use App\Models\Stand\StandAssignment;
+use Illuminate\Support\Collection;
+
+class StandAssignmentContext
+{
+    private readonly StandAssignment $assignment;
+
+    private readonly string $assignmentType;
+
+    private readonly Collection $removedAssignments;
+
+    public function __construct(StandAssignment $assignment, string $assignmentType, Collection $removedAssignments)
+    {
+        $this->assignment = $assignment;
+        $this->assignmentType = $assignmentType;
+        $this->removedAssignments = $removedAssignments;
+    }
+
+    public function assignment(): StandAssignment
+    {
+        return $this->assignment;
+    }
+
+    public function assignmentType(): string
+    {
+        return $this->assignmentType;
+    }
+
+    public function removedAssignments(): Collection
+    {
+        return $this->removedAssignments;
+    }
+}

--- a/app/Services/Stand/StandAssignmentContext.php
+++ b/app/Services/Stand/StandAssignmentContext.php
@@ -3,6 +3,7 @@
 namespace App\Services\Stand;
 
 use App\Models\Stand\StandAssignment;
+use App\Models\Vatsim\NetworkAircraft;
 use Illuminate\Support\Collection;
 
 class StandAssignmentContext
@@ -10,7 +11,8 @@ class StandAssignmentContext
     public function __construct(
         public readonly StandAssignment $assignment,
         public readonly string $assignmentType,
-        public readonly Collection $removedAssignments
+        public readonly Collection $removedAssignments,
+        public readonly NetworkAircraft $aircraft
     ) {
     }
 }

--- a/app/Services/Stand/StandAssignmentsHistoryService.php
+++ b/app/Services/Stand/StandAssignmentsHistoryService.php
@@ -28,8 +28,7 @@ class StandAssignmentsHistoryService implements RecordsAssignmentHistory
 
     public function createHistoryItem(StandAssignmentContext $context): void
     {
-        DB::transaction(function () use ($context)
-        {
+        DB::transaction(function () use ($context) {
             $assignment = $context->assignment;
             $this->deleteHistoryFor($assignment);
             StandAssignmentsHistory::create(
@@ -51,8 +50,7 @@ class StandAssignmentsHistoryService implements RecordsAssignmentHistory
             'aircraft_arrival_airfield' => $context->aircraft->planned_destairport,
             'aircraft_type' => $context->aircraft->planned_aircraft_short,
             'removed_assignments' => $context->removedAssignments->map(
-                function (StandAssignment $assignment)
-                {
+                function (StandAssignment $assignment) {
                     return [
                         'callsign' => $assignment->callsign,
                         'stand' => $assignment->stand->identifier,
@@ -64,21 +62,21 @@ class StandAssignmentsHistoryService implements RecordsAssignmentHistory
                 ->whereHas('occupier')
                 ->orderBy('stands.id')
                 ->get()
-                ->map(fn(Stand $stand) => $stand->identifier),
+                ->map(fn (Stand $stand) => $stand->identifier),
             'assigned_stands' => Stand::where('airfield_id', $context->assignment->stand->airfield_id)
                 ->where('id', '<>', $context->assignment->stand_id)
                 ->whereHas('assignment')
                 ->orderBy('stands.id')
                 ->get()
-                ->map(fn(Stand $stand) => $stand->identifier),
+                ->map(fn (Stand $stand) => $stand->identifier),
             'flightplan_remarks' => $context->aircraft->remarks,
             'requested_stand' => $this->standRequestService->activeRequestForAircraft($context->aircraft)
                 ?->stand->identifier,
             'other_requested_stands' => $this->standRequestService->allActiveStandRequestsForAirfield(
                 $context->assignment->stand->airfield->code
             )
-                ->filter(fn(StandRequest $request) => $request->stand_id !== $context->assignment->stand_id)
-                ->map(fn(StandRequest $request) => $request->stand->identifier)
+                ->filter(fn (StandRequest $request) => $request->stand_id !== $context->assignment->stand_id)
+                ->map(fn (StandRequest $request) => $request->stand->identifier)
                 ->values()
                 ->toArray(),
         ];

--- a/app/Services/Stand/StandAssignmentsHistoryService.php
+++ b/app/Services/Stand/StandAssignmentsHistoryService.php
@@ -36,6 +36,13 @@ class StandAssignmentsHistoryService implements RecordsAssignmentHistory
         });
     }
 
+    // TODO: Add aircraft type to context
+    // TODO: Add origin airfield to context
+    // TODO: Add destination airfield to context
+    // TODO: Add user request to context
+    // TODO: Add other active requests to context
+    // TODO: Add reservations to context
+    // TODO: Add fp remarks to context
     private function generateContext(StandAssignmentContext $context): array
     {
         return [

--- a/app/Services/Stand/StandAssignmentsHistoryService.php
+++ b/app/Services/Stand/StandAssignmentsHistoryService.php
@@ -44,7 +44,6 @@ class StandAssignmentsHistoryService implements RecordsAssignmentHistory
         });
     }
 
-    // TODO: Add reservations to context
     private function generateContext(StandAssignmentContext $context): array
     {
         return [

--- a/app/Services/Stand/StandAssignmentsHistoryService.php
+++ b/app/Services/Stand/StandAssignmentsHistoryService.php
@@ -22,13 +22,13 @@ class StandAssignmentsHistoryService implements RecordsAssignmentHistory
     {
         DB::transaction(function () use ($context)
         {
-            $assignment = $context->assignment();
+            $assignment = $context->assignment;
             $this->deleteHistoryFor($assignment);
             StandAssignmentsHistory::create(
                 [
                     'callsign' => $assignment->callsign,
                     'stand_id' => $assignment->stand_id,
-                    'type' => $context->assignmentType(),
+                    'type' => $context->assignmentType,
                     'user_id' => !is_null(Auth::user()) ? Auth::user()->id : null,
                     'context' => $this->generateContext($context),
                 ]
@@ -46,7 +46,7 @@ class StandAssignmentsHistoryService implements RecordsAssignmentHistory
     private function generateContext(StandAssignmentContext $context): array
     {
         return [
-            'removed_assignments' => $context->removedAssignments()->map(
+            'removed_assignments' => $context->removedAssignments->map(
                 function (StandAssignment $assignment)
                 {
                     return [
@@ -55,14 +55,14 @@ class StandAssignmentsHistoryService implements RecordsAssignmentHistory
                     ];
                 }
             ),
-            'occupied_stands' => Stand::where('airfield_id', $context->assignment()->stand->airfield_id)
-                ->where('id', '<>', $context->assignment()->stand_id)
+            'occupied_stands' => Stand::where('airfield_id', $context->assignment->stand->airfield_id)
+                ->where('id', '<>', $context->assignment->stand_id)
                 ->whereHas('occupier')
                 ->orderBy('stands.id')
                 ->get()
                 ->map(fn(Stand $stand) => $stand->identifier),
-            'assigned_stands' => Stand::where('airfield_id', $context->assignment()->stand->airfield_id)
-                ->where('id', '<>', $context->assignment()->stand_id)
+            'assigned_stands' => Stand::where('airfield_id', $context->assignment->stand->airfield_id)
+                ->where('id', '<>', $context->assignment->stand_id)
                 ->whereHas('assignment')
                 ->orderBy('stands.id')
                 ->get()

--- a/app/Services/Stand/StandAssignmentsHistoryService.php
+++ b/app/Services/Stand/StandAssignmentsHistoryService.php
@@ -28,7 +28,8 @@ class StandAssignmentsHistoryService implements RecordsAssignmentHistory
 
     public function createHistoryItem(StandAssignmentContext $context): void
     {
-        DB::transaction(function () use ($context) {
+        DB::transaction(function () use ($context)
+        {
             $assignment = $context->assignment;
             $this->deleteHistoryFor($assignment);
             StandAssignmentsHistory::create(
@@ -50,7 +51,8 @@ class StandAssignmentsHistoryService implements RecordsAssignmentHistory
             'aircraft_arrival_airfield' => $context->aircraft->planned_destairport,
             'aircraft_type' => $context->aircraft->planned_aircraft_short,
             'removed_assignments' => $context->removedAssignments->map(
-                function (StandAssignment $assignment) {
+                function (StandAssignment $assignment)
+                {
                     return [
                         'callsign' => $assignment->callsign,
                         'stand' => $assignment->stand->identifier,
@@ -62,18 +64,21 @@ class StandAssignmentsHistoryService implements RecordsAssignmentHistory
                 ->whereHas('occupier')
                 ->orderBy('stands.id')
                 ->get()
-                ->map(fn (Stand $stand) => $stand->identifier),
+                ->map(fn(Stand $stand) => $stand->identifier),
             'assigned_stands' => Stand::where('airfield_id', $context->assignment->stand->airfield_id)
                 ->where('id', '<>', $context->assignment->stand_id)
                 ->whereHas('assignment')
                 ->orderBy('stands.id')
                 ->get()
-                ->map(fn (Stand $stand) => $stand->identifier),
+                ->map(fn(Stand $stand) => $stand->identifier),
             'flightplan_remarks' => $context->aircraft->remarks,
-            'requested_stand' => $this->standRequestService->activeRequestForAircraft($context->aircraft)?->stand->identifier,
-            'other_requested_stands' => $this->standRequestService->allActiveStandRequestsForAirfield($context->assignment->stand->airfield->code)
-                ->filter(fn (StandRequest $request) => $request->stand_id !== $context->assignment->stand_id)
-                ->map(fn (StandRequest $request) => $request->stand->identifier)
+            'requested_stand' => $this->standRequestService->activeRequestForAircraft($context->aircraft)
+                ?->stand->identifier,
+            'other_requested_stands' => $this->standRequestService->allActiveStandRequestsForAirfield(
+                $context->assignment->stand->airfield->code
+            )
+                ->filter(fn(StandRequest $request) => $request->stand_id !== $context->assignment->stand_id)
+                ->map(fn(StandRequest $request) => $request->stand->identifier)
                 ->values()
                 ->toArray(),
         ];

--- a/app/Services/Stand/StandAssignmentsHistoryService.php
+++ b/app/Services/Stand/StandAssignmentsHistoryService.php
@@ -39,7 +39,6 @@ class StandAssignmentsHistoryService implements RecordsAssignmentHistory
     // TODO: Add user request to context
     // TODO: Add other active requests to context
     // TODO: Add reservations to context
-    // TODO: Add fp remarks to context
     private function generateContext(StandAssignmentContext $context): array
     {
         return [
@@ -67,6 +66,7 @@ class StandAssignmentsHistoryService implements RecordsAssignmentHistory
                 ->orderBy('stands.id')
                 ->get()
                 ->map(fn(Stand $stand) => $stand->identifier),
+            'flightplan_remarks' => $context->aircraft->remarks,
         ];
     }
 }

--- a/app/Services/Stand/StandAssignmentsHistoryService.php
+++ b/app/Services/Stand/StandAssignmentsHistoryService.php
@@ -28,8 +28,7 @@ class StandAssignmentsHistoryService implements RecordsAssignmentHistory
 
     public function createHistoryItem(StandAssignmentContext $context): void
     {
-        DB::transaction(function () use ($context)
-        {
+        DB::transaction(function () use ($context) {
             $assignment = $context->assignment;
             $this->deleteHistoryFor($assignment);
             StandAssignmentsHistory::create(
@@ -51,8 +50,7 @@ class StandAssignmentsHistoryService implements RecordsAssignmentHistory
             'aircraft_arrival_airfield' => $context->aircraft->planned_destairport,
             'aircraft_type' => $context->aircraft->planned_aircraft_short,
             'removed_assignments' => $context->removedAssignments->map(
-                function (StandAssignment $assignment)
-                {
+                function (StandAssignment $assignment) {
                     return [
                         'callsign' => $assignment->callsign,
                         'stand' => $assignment->stand->identifier,
@@ -64,18 +62,18 @@ class StandAssignmentsHistoryService implements RecordsAssignmentHistory
                 ->whereHas('occupier')
                 ->orderBy('stands.id')
                 ->get()
-                ->map(fn(Stand $stand) => $stand->identifier),
+                ->map(fn (Stand $stand) => $stand->identifier),
             'assigned_stands' => Stand::where('airfield_id', $context->assignment->stand->airfield_id)
                 ->where('id', '<>', $context->assignment->stand_id)
                 ->whereHas('assignment')
                 ->orderBy('stands.id')
                 ->get()
-                ->map(fn(Stand $stand) => $stand->identifier),
+                ->map(fn (Stand $stand) => $stand->identifier),
             'flightplan_remarks' => $context->aircraft->remarks,
             'requested_stand' => $this->standRequestService->activeRequestForAircraft($context->aircraft)?->stand->identifier,
             'other_requested_stands' => $this->standRequestService->allActiveStandRequestsForAirfield($context->assignment->stand->airfield->code)
-                ->filter(fn(StandRequest $request) => $request->stand_id !== $context->assignment->stand_id)
-                ->map(fn(StandRequest $request) => $request->stand->identifier)
+                ->filter(fn (StandRequest $request) => $request->stand_id !== $context->assignment->stand_id)
+                ->map(fn (StandRequest $request) => $request->stand->identifier)
                 ->values()
                 ->toArray(),
         ];

--- a/app/Services/Stand/StandAssignmentsHistoryService.php
+++ b/app/Services/Stand/StandAssignmentsHistoryService.php
@@ -2,12 +2,13 @@
 
 namespace App\Services\Stand;
 
+use App\Models\Stand\Stand;
 use App\Models\Stand\StandAssignment;
 use App\Models\Stand\StandAssignmentsHistory;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 
-class StandAssignmentsHistoryService
+class StandAssignmentsHistoryService implements RecordsAssignmentHistory
 {
     public function deleteHistoryFor(StandAssignment $target): void
     {
@@ -17,17 +18,48 @@ class StandAssignmentsHistoryService
         )->delete();
     }
 
-    public function createHistoryItem(StandAssignment $assignment): void
+    public function createHistoryItem(StandAssignmentContext $context): void
     {
-        DB::transaction(function () use ($assignment) {
+        DB::transaction(function () use ($context)
+        {
+            $assignment = $context->assignment();
             $this->deleteHistoryFor($assignment);
             StandAssignmentsHistory::create(
                 [
                     'callsign' => $assignment->callsign,
                     'stand_id' => $assignment->stand_id,
+                    'type' => $context->assignmentType(),
                     'user_id' => !is_null(Auth::user()) ? Auth::user()->id : null,
+                    'context' => $this->generateContext($context),
                 ]
             );
         });
+    }
+
+    private function generateContext(StandAssignmentContext $context): array
+    {
+        return [
+            'removed_assignments' => $context->removedAssignments()->map(
+                function (StandAssignment $assignment)
+                {
+                    return [
+                        'callsign' => $assignment->callsign,
+                        'stand' => $assignment->stand->identifier,
+                    ];
+                }
+            ),
+            'occupied_stands' => Stand::where('airfield_id', $context->assignment()->stand->airfield_id)
+                ->where('id', '<>', $context->assignment()->stand_id)
+                ->whereHas('occupier')
+                ->orderBy('stands.id')
+                ->get()
+                ->map(fn(Stand $stand) => $stand->identifier),
+            'assigned_stands' => Stand::where('airfield_id', $context->assignment()->stand->airfield_id)
+                ->where('id', '<>', $context->assignment()->stand_id)
+                ->whereHas('assignment')
+                ->orderBy('stands.id')
+                ->get()
+                ->map(fn(Stand $stand) => $stand->identifier),
+        ];
     }
 }

--- a/app/Services/Stand/StandAssignmentsHistoryService.php
+++ b/app/Services/Stand/StandAssignmentsHistoryService.php
@@ -13,7 +13,8 @@ class StandAssignmentsHistoryService implements RecordsAssignmentHistory
 {
     private readonly StandRequestService $standRequestService;
 
-    public function __construct(StandRequestService $standRequestService) {
+    public function __construct(StandRequestService $standRequestService)
+    {
         $this->standRequestService = $standRequestService;
     }
 
@@ -43,7 +44,6 @@ class StandAssignmentsHistoryService implements RecordsAssignmentHistory
         });
     }
 
-    // TODO: Add other active requests to context
     // TODO: Add reservations to context
     private function generateContext(StandAssignmentContext $context): array
     {
@@ -74,6 +74,11 @@ class StandAssignmentsHistoryService implements RecordsAssignmentHistory
                 ->map(fn(Stand $stand) => $stand->identifier),
             'flightplan_remarks' => $context->aircraft->remarks,
             'requested_stand' => $this->standRequestService->activeRequestForAircraft($context->aircraft)?->stand->identifier,
+            'other_requested_stands' => $this->standRequestService->allActiveStandRequestsForAirfield($context->assignment->stand->airfield->code)
+                ->filter(fn(StandRequest $request) => $request->stand_id !== $context->assignment->stand_id)
+                ->map(fn(StandRequest $request) => $request->stand->identifier)
+                ->values()
+                ->toArray(),
         ];
     }
 }

--- a/app/Services/Stand/StandAssignmentsHistoryService.php
+++ b/app/Services/Stand/StandAssignmentsHistoryService.php
@@ -5,11 +5,18 @@ namespace App\Services\Stand;
 use App\Models\Stand\Stand;
 use App\Models\Stand\StandAssignment;
 use App\Models\Stand\StandAssignmentsHistory;
+use App\Models\Stand\StandRequest;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 
 class StandAssignmentsHistoryService implements RecordsAssignmentHistory
 {
+    private readonly StandRequestService $standRequestService;
+
+    public function __construct(StandRequestService $standRequestService) {
+        $this->standRequestService = $standRequestService;
+    }
+
     public function deleteHistoryFor(StandAssignment $target): void
     {
         StandAssignmentsHistory::where(
@@ -36,7 +43,6 @@ class StandAssignmentsHistoryService implements RecordsAssignmentHistory
         });
     }
 
-    // TODO: Add user request to context
     // TODO: Add other active requests to context
     // TODO: Add reservations to context
     private function generateContext(StandAssignmentContext $context): array
@@ -67,6 +73,7 @@ class StandAssignmentsHistoryService implements RecordsAssignmentHistory
                 ->get()
                 ->map(fn(Stand $stand) => $stand->identifier),
             'flightplan_remarks' => $context->aircraft->remarks,
+            'requested_stand' => $this->standRequestService->activeRequestForAircraft($context->aircraft)?->stand->identifier,
         ];
     }
 }

--- a/app/Services/Stand/StandAssignmentsHistoryService.php
+++ b/app/Services/Stand/StandAssignmentsHistoryService.php
@@ -36,9 +36,6 @@ class StandAssignmentsHistoryService implements RecordsAssignmentHistory
         });
     }
 
-    // TODO: Add aircraft type to context
-    // TODO: Add origin airfield to context
-    // TODO: Add destination airfield to context
     // TODO: Add user request to context
     // TODO: Add other active requests to context
     // TODO: Add reservations to context
@@ -46,6 +43,9 @@ class StandAssignmentsHistoryService implements RecordsAssignmentHistory
     private function generateContext(StandAssignmentContext $context): array
     {
         return [
+            'aircraft_departure_airfield' => $context->aircraft->planned_depairport,
+            'aircraft_arrival_airfield' => $context->aircraft->planned_destairport,
+            'aircraft_type' => $context->aircraft->planned_aircraft_short,
             'removed_assignments' => $context->removedAssignments->map(
                 function (StandAssignment $assignment)
                 {

--- a/app/Services/Stand/StandAssignmentsService.php
+++ b/app/Services/Stand/StandAssignmentsService.php
@@ -48,8 +48,7 @@ class StandAssignmentsService
             throw new StandNotFoundException(sprintf('Stand with id %d not found', $standId));
         }
 
-        [$assignment, $existingAssignments] = DB::transaction(function () use ($callsign, $stand, $assignmentType)
-        {
+        [$assignment, $existingAssignments] = DB::transaction(function () use ($callsign, $stand, $assignmentType) {
             // Remove assignments for this and paired stands
             $existingAssignments = StandAssignment::with('stand')
                 ->where('stand_id', $stand->id)
@@ -62,8 +61,7 @@ class StandAssignmentsService
                 )
                 ->get();
 
-            $existingAssignments->each(function (StandAssignment $assignment)
-            {
+            $existingAssignments->each(function (StandAssignment $assignment) {
                 $this->deleteAssignmentAndHistoryData($assignment);
             });
 
@@ -82,8 +80,7 @@ class StandAssignmentsService
             return [$assignment, $existingAssignments];
         });
 
-        $existingAssignments->each(function (StandAssignment $assignment)
-        {
+        $existingAssignments->each(function (StandAssignment $assignment) {
             $this->unassignedEvent($assignment);
         });
         event(new StandAssignedEvent($assignment));
@@ -96,8 +93,7 @@ class StandAssignmentsService
 
     private function deleteAssignmentAndHistoryData(StandAssignment $assignment): void
     {
-        DB::transaction(function () use ($assignment)
-        {
+        DB::transaction(function () use ($assignment) {
             $assignment->delete();
             $this->historyService->deleteHistoryFor($assignment);
         });

--- a/app/Services/Stand/StandAssignmentsService.php
+++ b/app/Services/Stand/StandAssignmentsService.php
@@ -48,8 +48,7 @@ class StandAssignmentsService
             throw new StandNotFoundException(sprintf('Stand with id %d not found', $standId));
         }
 
-        [$assignment, $existingAssignments] = DB::transaction(function () use ($callsign, $stand, $assignmentType)
-        {
+        [$assignment, $existingAssignments] = DB::transaction(function () use ($callsign, $stand, $assignmentType) {
             // Remove assignments for this and paired stands
             $existingAssignments = StandAssignment::with('stand')
                 ->where('stand_id', $stand->id)
@@ -62,8 +61,7 @@ class StandAssignmentsService
                 )
                 ->get();
 
-            $existingAssignments->each(function (StandAssignment $assignment)
-            {
+            $existingAssignments->each(function (StandAssignment $assignment) {
                 $this->deleteAssignmentAndHistoryData($assignment);
             });
 
@@ -87,8 +85,7 @@ class StandAssignmentsService
             return [$assignment, $existingAssignments];
         });
 
-        $existingAssignments->each(function (StandAssignment $assignment)
-        {
+        $existingAssignments->each(function (StandAssignment $assignment) {
             $this->unassignedEvent($assignment);
         });
         event(new StandAssignedEvent($assignment));
@@ -101,8 +98,7 @@ class StandAssignmentsService
 
     private function deleteAssignmentAndHistoryData(StandAssignment $assignment): void
     {
-        DB::transaction(function () use ($assignment)
-        {
+        DB::transaction(function () use ($assignment) {
             $assignment->delete();
             $this->historyService->deleteHistoryFor($assignment);
         });

--- a/app/Services/Stand/StandAssignmentsService.php
+++ b/app/Services/Stand/StandAssignmentsService.php
@@ -76,7 +76,7 @@ class StandAssignmentsService
                 ]
             );
 
-            $assignmentContext = new StandAssignmentContext($assignment, $assignmentType, $existingAssignments);
+            $assignmentContext = new StandAssignmentContext($assignment, $assignmentType, $existingAssignments, $assignment->aircraft);
             $this->historyService->createHistoryItem($assignmentContext);
 
             return [$assignment, $existingAssignments];

--- a/app/Services/Stand/StandAssignmentsService.php
+++ b/app/Services/Stand/StandAssignmentsService.php
@@ -48,7 +48,8 @@ class StandAssignmentsService
             throw new StandNotFoundException(sprintf('Stand with id %d not found', $standId));
         }
 
-        [$assignment, $existingAssignments] = DB::transaction(function () use ($callsign, $stand, $assignmentType) {
+        [$assignment, $existingAssignments] = DB::transaction(function () use ($callsign, $stand, $assignmentType)
+        {
             // Remove assignments for this and paired stands
             $existingAssignments = StandAssignment::with('stand')
                 ->where('stand_id', $stand->id)
@@ -61,7 +62,8 @@ class StandAssignmentsService
                 )
                 ->get();
 
-            $existingAssignments->each(function (StandAssignment $assignment) {
+            $existingAssignments->each(function (StandAssignment $assignment)
+            {
                 $this->deleteAssignmentAndHistoryData($assignment);
             });
 
@@ -74,13 +76,19 @@ class StandAssignmentsService
                 ]
             );
 
-            $assignmentContext = new StandAssignmentContext($assignment, $assignmentType, $existingAssignments, $assignment->aircraft);
+            $assignmentContext = new StandAssignmentContext(
+                $assignment,
+                $assignmentType,
+                $existingAssignments,
+                $assignment->aircraft
+            );
             $this->historyService->createHistoryItem($assignmentContext);
 
             return [$assignment, $existingAssignments];
         });
 
-        $existingAssignments->each(function (StandAssignment $assignment) {
+        $existingAssignments->each(function (StandAssignment $assignment)
+        {
             $this->unassignedEvent($assignment);
         });
         event(new StandAssignedEvent($assignment));
@@ -93,7 +101,8 @@ class StandAssignmentsService
 
     private function deleteAssignmentAndHistoryData(StandAssignment $assignment): void
     {
-        DB::transaction(function () use ($assignment) {
+        DB::transaction(function () use ($assignment)
+        {
             $assignment->delete();
             $this->historyService->deleteHistoryFor($assignment);
         });

--- a/app/Services/Stand/StandRequestService.php
+++ b/app/Services/Stand/StandRequestService.php
@@ -4,6 +4,7 @@ namespace App\Services\Stand;
 
 use App\Models\Stand\StandRequest;
 use App\Models\Vatsim\NetworkAircraft;
+use Illuminate\Support\Collection;
 
 class StandRequestService
 {
@@ -18,5 +19,17 @@ class StandRequestService
             ->where('user_id', $aircraft->cid)
             ->where('callsign', $aircraft->callsign)
             ->first();
+    }
+
+    public function allActiveStandRequestsForAirfield(string $airfield): Collection
+    {
+        return StandRequest::with('stand')
+            ->current()
+            ->whereHas('stand.airfield', function ($query) use ($airfield)
+            {
+                $query->where('code', $airfield);
+            })
+            ->orderBy('id')
+            ->get();
     }
 }

--- a/app/Services/Stand/StandRequestService.php
+++ b/app/Services/Stand/StandRequestService.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Services\Stand;
+
+use App\Models\Stand\StandRequest;
+use App\Models\Vatsim\NetworkAircraft;
+
+class StandRequestService
+{
+    public function activeRequestForAircraft(NetworkAircraft $aircraft): ?StandRequest
+    {
+        if (!$aircraft->cid) {
+            return null;
+        }
+
+        return StandRequest::with('stand')
+            ->current()
+            ->where('user_id', $aircraft->cid)
+            ->where('callsign', $aircraft->callsign)
+            ->first();
+    }
+}

--- a/app/Services/Stand/StandRequestService.php
+++ b/app/Services/Stand/StandRequestService.php
@@ -25,8 +25,7 @@ class StandRequestService
     {
         return StandRequest::with('stand')
             ->current()
-            ->whereHas('stand.airfield', function ($query) use ($airfield)
-            {
+            ->whereHas('stand.airfield', function ($query) use ($airfield) {
                 $query->where('code', $airfield);
             })
             ->orderBy('id')

--- a/app/Services/Stand/StandStatusService.php
+++ b/app/Services/Stand/StandStatusService.php
@@ -36,15 +36,13 @@ class StandStatusService
             ->airfield($airfield)
             ->get();
 
-        $stands->sortBy('identifier', SORT_NATURAL);
-
-        $standStatuses = [];
-
-        foreach ($stands as $stand) {
-            $standStatuses[] = self::getStandStatus($stand);
-        }
-
-        return $standStatuses;
+        return $stands->sortBy('identifier', SORT_NATURAL)
+            ->values()
+            ->map(function (Stand $stand)
+            {
+                return self::getStandStatus($stand);
+            })
+            ->toArray();
     }
 
     public static function getStandStatus(Stand $stand): array
@@ -54,10 +52,13 @@ class StandStatusService
             'type' => $stand->type ? $stand->type->key : null,
             'latitude' => $stand->latitude,
             'longitude' => $stand->longitude,
-            'airlines' => $stand->airlines->groupBy('icao_code')->map(function (Collection $airlineDestination) {
-                return $airlineDestination->filter(function (Airline $airline) {
+            'airlines' => $stand->airlines->groupBy('icao_code')->map(function (Collection $airlineDestination)
+            {
+                return $airlineDestination->filter(function (Airline $airline)
+                {
                     return $airline->pivot->destination;
-                })->map(function (Airline $airline) {
+                })->map(function (Airline $airline)
+                {
                     return $airline->pivot->destination;
                 });
             })->toArray(),
@@ -84,7 +85,8 @@ class StandStatusService
             $standData['reserved_at'] = $stand->reservationsInNextHour->first()->start;
             $standData['callsign'] = $stand->reservationsInNextHour->first()->callsign;
         } elseif (
-            !$stand->pairedStands->filter(function (Stand $stand) {
+            !$stand->pairedStands->filter(function (Stand $stand)
+            {
                 return $stand->assignment ||
                     !$stand->occupier->isEmpty() ||
                     !$stand->activeReservations->isEmpty();

--- a/app/Services/Stand/StandStatusService.php
+++ b/app/Services/Stand/StandStatusService.php
@@ -38,8 +38,7 @@ class StandStatusService
 
         return $stands->sortBy('identifier', SORT_NATURAL)
             ->values()
-            ->map(function (Stand $stand)
-            {
+            ->map(function (Stand $stand) {
                 return self::getStandStatus($stand);
             })
             ->toArray();
@@ -52,13 +51,10 @@ class StandStatusService
             'type' => $stand->type ? $stand->type->key : null,
             'latitude' => $stand->latitude,
             'longitude' => $stand->longitude,
-            'airlines' => $stand->airlines->groupBy('icao_code')->map(function (Collection $airlineDestination)
-            {
-                return $airlineDestination->filter(function (Airline $airline)
-                {
+            'airlines' => $stand->airlines->groupBy('icao_code')->map(function (Collection $airlineDestination) {
+                return $airlineDestination->filter(function (Airline $airline) {
                     return $airline->pivot->destination;
-                })->map(function (Airline $airline)
-                {
+                })->map(function (Airline $airline) {
                     return $airline->pivot->destination;
                 });
             })->toArray(),
@@ -85,8 +81,7 @@ class StandStatusService
             $standData['reserved_at'] = $stand->reservationsInNextHour->first()->start;
             $standData['callsign'] = $stand->reservationsInNextHour->first()->callsign;
         } elseif (
-            !$stand->pairedStands->filter(function (Stand $stand)
-            {
+            !$stand->pairedStands->filter(function (Stand $stand) {
                 return $stand->assignment ||
                     !$stand->occupier->isEmpty() ||
                     !$stand->activeReservations->isEmpty();

--- a/database/migrations/2023_08_28_112617_add_context_to_stand_assignments_history_table.php
+++ b/database/migrations/2023_08_28_112617_add_context_to_stand_assignments_history_table.php
@@ -4,15 +4,13 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class extends Migration {
     /**
      * Run the migrations.
      */
     public function up(): void
     {
-        Schema::table('stand_assignments_history', function (Blueprint $table)
-        {
+        Schema::table('stand_assignments_history', function (Blueprint $table) {
             $table->json('context')
                 ->nullable()
                 ->after('user_id')
@@ -25,8 +23,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('stand_assignments_history', function (Blueprint $table)
-        {
+        Schema::table('stand_assignments_history', function (Blueprint $table) {
             $table->dropColumn('context');
         });
     }

--- a/database/migrations/2023_08_28_112617_add_context_to_stand_assignments_history_table.php
+++ b/database/migrations/2023_08_28_112617_add_context_to_stand_assignments_history_table.php
@@ -14,7 +14,6 @@ return new class extends Migration
         Schema::table('stand_assignments_history', function (Blueprint $table)
         {
             $table->json('context')
-                ->default('{}')
                 ->nullable()
                 ->after('user_id')
                 ->comment('Contextual information about the assignment');

--- a/database/migrations/2023_08_28_112617_add_context_to_stand_assignments_history_table.php
+++ b/database/migrations/2023_08_28_112617_add_context_to_stand_assignments_history_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('stand_assignments_history', function (Blueprint $table)
+        {
+            $table->json('context')
+                ->default('{}')
+                ->nullable()
+                ->after('user_id')
+                ->comment('Contextual information about the assignment');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('stand_assignments_history', function (Blueprint $table)
+        {
+            $table->dropColumn('context');
+        });
+    }
+};

--- a/database/migrations/2023_08_28_124027_add_type_column_to_stand_assignments_history_table.php
+++ b/database/migrations/2023_08_28_124027_add_type_column_to_stand_assignments_history_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('stand_assignments_history', function (Blueprint $table)
+        {
+            $table->string('type')
+                ->default('unknown')
+                ->index()
+                ->after('stand_id')
+                ->comment('The type of assignment, e.g. the rule name, departure');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('stand_assignments_history', function (Blueprint $table)
+        {
+            $table->dropColumn('type');
+        });
+    }
+};

--- a/database/migrations/2023_08_28_124027_add_type_column_to_stand_assignments_history_table.php
+++ b/database/migrations/2023_08_28_124027_add_type_column_to_stand_assignments_history_table.php
@@ -4,15 +4,13 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class extends Migration {
     /**
      * Run the migrations.
      */
     public function up(): void
     {
-        Schema::table('stand_assignments_history', function (Blueprint $table)
-        {
+        Schema::table('stand_assignments_history', function (Blueprint $table) {
             $table->string('type')
                 ->default('unknown')
                 ->index()
@@ -26,8 +24,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('stand_assignments_history', function (Blueprint $table)
-        {
+        Schema::table('stand_assignments_history', function (Blueprint $table) {
             $table->dropColumn('type');
         });
     }

--- a/database/seeds/NetworkAircraftTableSeeder.php
+++ b/database/seeds/NetworkAircraftTableSeeder.php
@@ -28,6 +28,7 @@ class NetworkAircraftTableSeeder extends Seeder
                     'planned_route' => 'DIRECT',
                     'created_at' => '2020-05-30 17:30:00',
                     'updated_at' => Carbon::now()->subMinutes(9),
+                    'remarks' => 'BAW123 Remarks',
                 ],
                 [
                     'callsign' => 'BAW456',
@@ -47,6 +48,7 @@ class NetworkAircraftTableSeeder extends Seeder
                     'planned_route' => 'DIRECT',
                     'created_at' => Carbon::now()->subMinutes(31),
                     'updated_at' => Carbon::now(),
+                    'remarks' => 'BAW456 Remarks',
                 ],
                 [
                     'callsign' => 'BAW789',
@@ -66,6 +68,7 @@ class NetworkAircraftTableSeeder extends Seeder
                     'planned_route' => 'DIRECT',
                     'created_at' => Carbon::now()->subMinutes(31),
                     'updated_at' => Carbon::now()->subMinutes(21),
+                    'remarks' => 'BAW789 Remarks',
                 ],
                 [
                     'callsign' => 'RYR824',
@@ -85,6 +88,7 @@ class NetworkAircraftTableSeeder extends Seeder
                     'planned_route' => 'DIRECT',
                     'created_at' => '2020-05-30 17:30:00',
                     'updated_at' => Carbon::now()->subMinutes(10),
+                    'remarks' => 'RYR824 Remarks',
                 ],
             ]
         );

--- a/lang/en/stand_assignments_history/table.php
+++ b/lang/en/stand_assignments_history/table.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'columns' => [
+        'callsign' => 'Callsign',
+        'identifier' => 'Identifier',
+        'assigned_at' => 'Assigned At',
+        'deleted_at' => 'Unassigned At',
+        'type' => 'Assignment Type',
+        'context' => 'Context',
+    ],
+];

--- a/lang/en/table.php
+++ b/lang/en/table.php
@@ -8,6 +8,7 @@ return [
     'fir_exit_points' => require_once __DIR__ . '/fir_exit_points/table.php',
     'intention' => require_once __DIR__ . '/intention/table.php',
     'stands' => require_once __DIR__ . '/stands/table.php',
+    'stand_assignments_history' => require_once __DIR__ . '/stand_assignments_history/table.php',
     'users' => require_once __DIR__ . '/users/table.php',
     'sids' => require_once __DIR__ . '/sids/table.php',
     'handoffs' => require_once __DIR__ . '/handoffs/table.php',

--- a/resources/views/filament/forms/stand_assignment_history_context.blade.php
+++ b/resources/views/filament/forms/stand_assignment_history_context.blade.php
@@ -41,7 +41,7 @@
     @else
         No stand requested.
     @endif
-    <br />
+    <br /><br />
     {{-- All the stands that were assigned at assignment time --}}
     @if (isset($this->record->context['assigned_stands']))
         <h2><b>Assigned Stands</b></h2>
@@ -54,7 +54,7 @@
                 @endforeach
             </ol>
         @endif
-        <br />
+        <br /><br />
     @endif
     {{-- All the stands that were occupied at assignment time --}}
     @if (isset($this->record->context['occupied_stands']))
@@ -68,7 +68,7 @@
                 @endforeach
             </ol>
         @endif
-        <br /><br />
+        <br />
     @endif
     {{-- All the stands that were requested assignment time --}}
     @if (isset($this->record->context['other_requested_stands']))
@@ -82,7 +82,7 @@
                 @endforeach
             </ol>
         @endif
-        <br /><br />
+        <br />
     @endif
     {{-- All the stands that were unassigned as a result --}}
     @if (isset($this->record->context['removed_assignments']))

--- a/resources/views/filament/forms/stand_assignment_history_context.blade.php
+++ b/resources/views/filament/forms/stand_assignment_history_context.blade.php
@@ -34,6 +34,14 @@
     <h1><b>Assignment Type</b></h1>
     <p>{{ $this->record->type }}</p>
     <br />
+    {{-- The stand the user had requested at assignment time --}}
+    <h2><b>User Requested Stand</b></h2>
+    @if (isset($this->record->context['requested_stand']))
+        {{ $this->record->context['requested_stand'] }}
+    @else
+        No stand requested.
+    @endif
+    <br />
     {{-- All the stands that were assigned at assignment time --}}
     @if (isset($this->record->context['assigned_stands']))
         <h2><b>Assigned Stands</b></h2>
@@ -46,7 +54,7 @@
                 @endforeach
             </ol>
         @endif
-        <br/>
+        <br />
     @endif
     {{-- All the stands that were occupied at assignment time --}}
     @if (isset($this->record->context['occupied_stands']))
@@ -60,7 +68,7 @@
                 @endforeach
             </ol>
         @endif
-        <br/><br/>
+        <br /><br />
     @endif
     {{-- All the stands that were unassigned as a result --}}
     @if (isset($this->record->context['removed_assignments']))
@@ -74,6 +82,6 @@
                 @endforeach
             </ol>
         @endif
-        <br/>
+        <br />
     @endif
 </div>

--- a/resources/views/filament/forms/stand_assignment_history_context.blade.php
+++ b/resources/views/filament/forms/stand_assignment_history_context.blade.php
@@ -70,6 +70,20 @@
         @endif
         <br /><br />
     @endif
+    {{-- All the stands that were requested assignment time --}}
+    @if (isset($this->record->context['other_requested_stands']))
+        <h2><b>Other Requested Stands</b></h2>
+        @if (count($this->record->context['other_requested_stands']) === 0)
+            No stands requested.
+        @else
+            <ol>
+                @foreach ($this->record->context['other_requested_stands'] as $stand)
+                    <li>{{ $stand }}</li>
+                @endforeach
+            </ol>
+        @endif
+        <br /><br />
+    @endif
     {{-- All the stands that were unassigned as a result --}}
     @if (isset($this->record->context['removed_assignments']))
         <h2><b>Assignments Removed</b></h2>

--- a/resources/views/filament/forms/stand_assignment_history_context.blade.php
+++ b/resources/views/filament/forms/stand_assignment_history_context.blade.php
@@ -1,0 +1,61 @@
+<div>
+    <h1><b>Callsign</b></h1>
+    <p>{{ $this->record->callsign }}</p>
+    <br />
+    <h1><b>Stand</b></h1>
+    <p>{{ $this->record->stand->airfieldIdentifier }}</p>
+    <br />
+    <h1><b>Assigned At</b></h1>
+    <p>{{ $this->record->assigned_at }}</p>
+    <br />
+    <h1><b>Unassigned At</b></h1>
+    <p>{{ $this->record->deleted_at ?? '--' }}</p>
+    <br />
+    <h1><b>Assignment Type</b></h1>
+    <p>{{ $this->record->type }}</p>
+    <br />
+    {{-- All the stands that were assigned at assignment time --}}
+    @if (isset($this->record->context['assigned_stands']))
+        <h2><b>Assigned Stands</b></h2>
+        @if (count($this->record->context['assigned_stands']) === 0)
+            No stands assigned.
+        @else
+            <ol>
+                @foreach ($this->record->context['assigned_stands'] as $stand)
+                    <li>{{ $stand }}</li>
+                @endforeach
+            </ol>
+        @endif
+
+    @endif
+    </br>
+    {{-- All the stands that were occupied at assignment time --}}
+    @if (isset($this->record->context['occupied_stands']))
+        <h2><b>Occupied Stands</b></h2>
+        @if (count($this->record->context['occupied_stands']) === 0)
+            No stands occupied.
+        @else
+            <ol>
+                @foreach ($this->record->context['occupied_stands'] as $stand)
+                    <li>{{ $stand }}</li>
+                @endforeach
+            </ol>
+        @endif
+
+    @endif
+        </br>
+    {{-- All the stands that were unassigned as a result --}}
+    @if (isset($this->record->context['removed_assignments']))
+        <h2><b>Assignments Removed</b></h2>
+        @if (count($this->record->context['removed_assignments']) === 0)
+            No stand assignments were removed as a result of this assignment.
+        @else
+            <ol>
+                @foreach ($this->record->context['removed_assignments'] as $assignment)
+                    <li>{{ $assignment['callsign'] }}</li>
+                @endforeach
+            </ol>
+        @endif
+
+    @endif
+</div>

--- a/resources/views/filament/forms/stand_assignment_history_context.blade.php
+++ b/resources/views/filament/forms/stand_assignment_history_context.blade.php
@@ -2,6 +2,21 @@
     <h1><b>Callsign</b></h1>
     <p>{{ $this->record->callsign }}</p>
     <br />
+    @if (isset($this->record->context['aircraft_type']))
+        <h1><b>Aircraft Type</b></h1>
+        <p>{{ $this->record->context['aircraft_type'] }}</p>
+        <br />
+    @endif
+    @if (isset($this->record->context['aircraft_departure_airfield']))
+        <h1><b>Departure Airfield</b></h1>
+        <p>{{ $this->record->context['aircraft_departure_airfield'] }}</p>
+        <br />
+    @endif
+    @if (isset($this->record->context['aircraft_arrival_airfield']))
+        <h1><b>Arrival Airfield</b></h1>
+        <p>{{ $this->record->context['aircraft_arrival_airfield'] }}</p>
+        <br />
+    @endif
     <h1><b>Stand</b></h1>
     <p>{{ $this->record->stand->airfieldIdentifier }}</p>
     <br />
@@ -26,9 +41,8 @@
                 @endforeach
             </ol>
         @endif
-
+        <br/>
     @endif
-    </br>
     {{-- All the stands that were occupied at assignment time --}}
     @if (isset($this->record->context['occupied_stands']))
         <h2><b>Occupied Stands</b></h2>
@@ -41,9 +55,8 @@
                 @endforeach
             </ol>
         @endif
-
+        <br/><br/>
     @endif
-        </br>
     {{-- All the stands that were unassigned as a result --}}
     @if (isset($this->record->context['removed_assignments']))
         <h2><b>Assignments Removed</b></h2>
@@ -56,6 +69,6 @@
                 @endforeach
             </ol>
         @endif
-
+        <br/>
     @endif
 </div>

--- a/resources/views/filament/forms/stand_assignment_history_context.blade.php
+++ b/resources/views/filament/forms/stand_assignment_history_context.blade.php
@@ -17,6 +17,11 @@
         <p>{{ $this->record->context['aircraft_arrival_airfield'] }}</p>
         <br />
     @endif
+    @if (isset($this->record->context['flightplan_remarks']))
+        <h1><b>Flightplan Remarks</b></h1>
+        <p>{{ $this->record->context['flightplan_remarks'] }}</p>
+        <br />
+    @endif
     <h1><b>Stand</b></h1>
     <p>{{ $this->record->stand->airfieldIdentifier }}</p>
     <br />

--- a/tests/app/Filament/BaseChecksActionVisibility.php
+++ b/tests/app/Filament/BaseChecksActionVisibility.php
@@ -81,7 +81,7 @@ trait BaseChecksActionVisibility
                                     $relationManager,
                                     static::relationManagerLivewireParams(
                                         static::resourceRecordClass(),
-                                        static::resourceId(),
+                                        static::getResourceIdFromTest(),
                                     )
                                 );
 
@@ -124,13 +124,13 @@ trait BaseChecksActionVisibility
                         {
                             $livewire = Livewire::test(
                                 static::resourceListingClass(),
-                                static::resourceLivewireParams(static::resourceId())
+                                static::resourceLivewireParams(static::getResourceIdFromTest())
                             );
 
                             static::assertTableActionVisibility(
                                 $livewire,
                                 static::resourceRecordClass(),
-                                static::resourceId(),
+                                static::getResourceIdFromTest(),
                                 $action,
                                 in_array(
                                     $role,
@@ -165,7 +165,7 @@ trait BaseChecksActionVisibility
                         {
                             $livewire = Livewire::test(
                                 static::resourceListingClass(),
-                                static::resourceLivewireParams(static::resourceId())
+                                static::resourceLivewireParams(static::getResourceIdFromTest())
                             );
 
                             /*
@@ -229,6 +229,13 @@ trait BaseChecksActionVisibility
         ];
     }
 
+    private static function getResourceIdFromTest(): int|string
+    {
+        return is_callable(static::resourceId())
+            ? call_user_func(static::resourceId())
+            : static::resourceId();
+    }
+
     protected static function tableActionRecordClass(): array
     {
         return [];
@@ -239,7 +246,7 @@ trait BaseChecksActionVisibility
         return [];
     }
 
-    protected static function resourceId(): int|string
+    protected static function resourceId(): int|string|callable
     {
         return '';
     }

--- a/tests/app/Filament/ChecksHasRoleFilamentActionVisibility.php
+++ b/tests/app/Filament/ChecksHasRoleFilamentActionVisibility.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Filament;
+
+use App\Models\User\RoleKeys;
+
+trait ChecksHasRoleFilamentActionVisibility
+{
+    use BaseChecksActionVisibility;
+
+    private static function readOnlyRoles(): array
+    {
+        return [
+            RoleKeys::OPERATIONS_TEAM,
+            RoleKeys::WEB_TEAM,
+            RoleKeys::DIVISION_STAFF_GROUP,
+            RoleKeys::OPERATIONS_CONTRIBUTOR,
+        ];
+    }
+
+    private static function writeRoles(): array
+    {
+        return [
+            RoleKeys::OPERATIONS_TEAM,
+            RoleKeys::WEB_TEAM,
+            RoleKeys::DIVISION_STAFF_GROUP,
+        ];
+    }
+
+    private static function rolesToIterate(): array
+    {
+        return [
+            RoleKeys::OPERATIONS_TEAM,
+            RoleKeys::WEB_TEAM,
+            RoleKeys::DIVISION_STAFF_GROUP,
+            RoleKeys::OPERATIONS_CONTRIBUTOR,
+        ];
+    }
+}

--- a/tests/app/Filament/StandAssignmentsHistoryResourceTest.php
+++ b/tests/app/Filament/StandAssignmentsHistoryResourceTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Filament;
+
+use App\BaseFilamentTestCase;
+use App\Filament\AccessCheckingHelpers\ChecksListingFilamentAccess;
+use App\Filament\Resources\StandAssignmentsHistoryResource;
+use App\Models\Stand\Stand;
+use App\Models\Stand\StandAssignmentsHistory;
+use Carbon\Carbon;
+
+class StandAssignmentsHistoryResourceTest extends BaseFilamentTestCase
+{
+    use ChecksListingFilamentAccess;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        Carbon::setTestNow(Carbon::now()->startOfSecond());
+    }
+
+    protected function getIndexText(): array
+    {
+        return ['Stand Assignment Histories'];
+    }
+
+    protected function resourceClass(): string
+    {
+        return StandAssignmentsHistoryResource::class;
+    }
+
+    protected function beforeListing(): void
+    {
+        StandAssignmentsHistory::create(
+            [
+                'stand_id' => Stand::factory()->create()->id,
+                'callsign' => 'BAW123',
+                'assigned_at' => Carbon::now(),
+                'type' => 'TEST',
+                'context' => [],
+            ]
+        );
+    }
+}

--- a/tests/app/Filament/StandAssignmentsHistoryResourceTest.php
+++ b/tests/app/Filament/StandAssignmentsHistoryResourceTest.php
@@ -5,6 +5,7 @@ namespace App\Filament;
 use App\BaseFilamentTestCase;
 use App\Filament\AccessCheckingHelpers\ChecksListingFilamentAccess;
 use App\Filament\Resources\StandAssignmentsHistoryResource;
+use App\Filament\Resources\StandAssignmentsHistoryResource\Pages\ListStandAssignmentsHistories;
 use App\Models\Stand\Stand;
 use App\Models\Stand\StandAssignmentsHistory;
 use Carbon\Carbon;
@@ -12,12 +13,14 @@ use Carbon\Carbon;
 class StandAssignmentsHistoryResourceTest extends BaseFilamentTestCase
 {
     use ChecksListingFilamentAccess;
+    use ChecksDefaultFilamentActionVisibility;
 
     public function setUp(): void
     {
         parent::setUp();
         Carbon::setTestNow(Carbon::now()->startOfSecond());
     }
+
 
     protected function getIndexText(): array
     {
@@ -27,6 +30,34 @@ class StandAssignmentsHistoryResourceTest extends BaseFilamentTestCase
     protected function resourceClass(): string
     {
         return StandAssignmentsHistoryResource::class;
+    }
+
+    protected static function readOnlyResourceTableActions(): array
+    {
+        return ['view_context'];
+    }
+
+    protected static function resourceRecordClass(): string
+    {
+        return StandAssignmentsHistory::class;
+    }
+
+    protected static function resourceListingClass(): string
+    {
+        return ListStandAssignmentsHistories::class;
+    }
+
+    protected static function resourceId(): int|string|callable
+    {
+        return fn() => StandAssignmentsHistory::create(
+            [
+                'stand_id' => Stand::factory()->create()->id,
+                'callsign' => 'BAW123',
+                'assigned_at' => Carbon::now(),
+                'type' => 'TEST',
+                'context' => [],
+            ]
+        )->id;
     }
 
     protected function beforeListing(): void

--- a/tests/app/Filament/StandAssignmentsHistoryResourceTest.php
+++ b/tests/app/Filament/StandAssignmentsHistoryResourceTest.php
@@ -101,7 +101,50 @@ class StandAssignmentsHistoryResourceTest extends BaseFilamentTestCase
         // Test filter before and after
         Livewire::test(ListStandAssignmentsHistories::class)
             ->assertCanSeeTableRecords([$item1, $item2, $item3])
-            ->filterTable('airfield', $airfield1->id)
+            ->filterTable('airfield_and_stand', ['airfield' => $airfield1->id])
+            ->assertCanSeeTableRecords([$item1, $item3])
+            ->assertCanNotSeeTableRecords([$item2]);
+    }
+
+    public function testItAllowsFilteredResultsByStand()
+    {
+        $stand1 = Stand::factory()->create(['airfield_id' => 1]);
+        $stand2 = Stand::factory()->create(['airfield_id' => 1]);
+
+        $item1 = StandAssignmentsHistory::create(
+            [
+                'callsign' => 'BAW123',
+                'assigned_at' => Carbon::now()->subDays(1),
+                'type' => 'TEST',
+                'context' => [],
+                'stand_id' => $stand1->id,
+            ]
+        );
+
+        $item2 = StandAssignmentsHistory::create(
+            [
+                'callsign' => 'BAW999',
+                'assigned_at' => Carbon::now()->subDays(1),
+                'type' => 'TEST',
+                'context' => [],
+                'stand_id' => $stand2->id,
+            ]
+        );
+
+        $item3 = StandAssignmentsHistory::create(
+            [
+                'callsign' => 'BAW777',
+                'assigned_at' => Carbon::now()->subDays(1),
+                'type' => 'TEST',
+                'context' => [],
+                'stand_id' => $stand1->id,
+            ]
+        );
+
+        // Test filter before and after
+        Livewire::test(ListStandAssignmentsHistories::class)
+            ->assertCanSeeTableRecords([$item1, $item2, $item3])
+            ->filterTable('airfield_and_stand', ['airfield' => 1, 'stand' => $stand1->id])
             ->assertCanSeeTableRecords([$item1, $item3])
             ->assertCanNotSeeTableRecords([$item2]);
     }

--- a/tests/app/Filament/StandAssignmentsHistoryResourceTest.php
+++ b/tests/app/Filament/StandAssignmentsHistoryResourceTest.php
@@ -9,6 +9,7 @@ use App\Filament\Resources\StandAssignmentsHistoryResource\Pages\ListStandAssign
 use App\Models\Stand\Stand;
 use App\Models\Stand\StandAssignmentsHistory;
 use Carbon\Carbon;
+use Livewire\Livewire;
 
 class StandAssignmentsHistoryResourceTest extends BaseFilamentTestCase
 {
@@ -21,6 +22,45 @@ class StandAssignmentsHistoryResourceTest extends BaseFilamentTestCase
         Carbon::setTestNow(Carbon::now()->startOfSecond());
     }
 
+    public function testItAllowsFilteredResultsByCallsign()
+    {
+        $item1 = StandAssignmentsHistory::create(
+            [
+                'callsign' => 'BAW123',
+                'assigned_at' => Carbon::now()->subDays(1),
+                'type' => 'TEST',
+                'context' => [],
+                'stand_id' => Stand::factory()->create()->id,
+            ]
+        );
+
+        $item2 = StandAssignmentsHistory::create(
+            [
+                'callsign' => 'BAW999',
+                'assigned_at' => Carbon::now()->subDays(1),
+                'type' => 'TEST',
+                'context' => [],
+                'stand_id' => Stand::factory()->create()->id,
+            ]
+        );
+
+        $item3 = StandAssignmentsHistory::create(
+            [
+                'callsign' => 'BAW123',
+                'assigned_at' => Carbon::now()->subDays(1),
+                'type' => 'TEST',
+                'context' => [],
+                'stand_id' => Stand::factory()->create()->id,
+            ]
+        );
+
+        // Test filter before and after
+        Livewire::test(ListStandAssignmentsHistories::class)
+            ->assertCanSeeTableRecords([$item1, $item2, $item3])
+            ->filterTable('callsign', ['isActive' => 'BAW123'])
+            ->assertCanSeeTableRecords([$item1, $item3])
+            ->assertCanNotSeeTableRecords([$item2]);
+    }
 
     protected function getIndexText(): array
     {

--- a/tests/app/Filament/StandAssignmentsHistoryResourceTest.php
+++ b/tests/app/Filament/StandAssignmentsHistoryResourceTest.php
@@ -6,6 +6,7 @@ use App\BaseFilamentTestCase;
 use App\Filament\AccessCheckingHelpers\ChecksListingFilamentAccess;
 use App\Filament\Resources\StandAssignmentsHistoryResource;
 use App\Filament\Resources\StandAssignmentsHistoryResource\Pages\ListStandAssignmentsHistories;
+use App\Models\Airfield\Airfield;
 use App\Models\Stand\Stand;
 use App\Models\Stand\StandAssignmentsHistory;
 use Carbon\Carbon;
@@ -58,6 +59,49 @@ class StandAssignmentsHistoryResourceTest extends BaseFilamentTestCase
         Livewire::test(ListStandAssignmentsHistories::class)
             ->assertCanSeeTableRecords([$item1, $item2, $item3])
             ->filterTable('callsign', ['isActive' => 'BAW123'])
+            ->assertCanSeeTableRecords([$item1, $item3])
+            ->assertCanNotSeeTableRecords([$item2]);
+    }
+
+    public function testItAllowsFilteredResultsByAirfield()
+    {
+        $airfield1 = Airfield::factory()->create();
+        $airfield2 = Airfield::factory()->create();
+
+        $item1 = StandAssignmentsHistory::create(
+            [
+                'callsign' => 'BAW123',
+                'assigned_at' => Carbon::now()->subDays(1),
+                'type' => 'TEST',
+                'context' => [],
+                'stand_id' => Stand::factory()->create(['airfield_id' => $airfield1->id])->id,
+            ]
+        );
+
+        $item2 = StandAssignmentsHistory::create(
+            [
+                'callsign' => 'BAW999',
+                'assigned_at' => Carbon::now()->subDays(1),
+                'type' => 'TEST',
+                'context' => [],
+                'stand_id' => Stand::factory()->create(['airfield_id' => $airfield2->id])->id,
+            ]
+        );
+
+        $item3 = StandAssignmentsHistory::create(
+            [
+                'callsign' => 'BAW777',
+                'assigned_at' => Carbon::now()->subDays(1),
+                'type' => 'TEST',
+                'context' => [],
+                'stand_id' => Stand::factory()->create(['airfield_id' => $airfield1->id])->id,
+            ]
+        );
+
+        // Test filter before and after
+        Livewire::test(ListStandAssignmentsHistories::class)
+            ->assertCanSeeTableRecords([$item1, $item2, $item3])
+            ->filterTable('airfield', $airfield1->id)
             ->assertCanSeeTableRecords([$item1, $item3])
             ->assertCanNotSeeTableRecords([$item2]);
     }

--- a/tests/app/Filament/StandAssignmentsHistoryResourceTest.php
+++ b/tests/app/Filament/StandAssignmentsHistoryResourceTest.php
@@ -9,13 +9,14 @@ use App\Filament\Resources\StandAssignmentsHistoryResource\Pages\ListStandAssign
 use App\Models\Airfield\Airfield;
 use App\Models\Stand\Stand;
 use App\Models\Stand\StandAssignmentsHistory;
+use App\Models\User\RoleKeys;
 use Carbon\Carbon;
 use Livewire\Livewire;
 
 class StandAssignmentsHistoryResourceTest extends BaseFilamentTestCase
 {
     use ChecksListingFilamentAccess;
-    use ChecksDefaultFilamentActionVisibility;
+    use ChecksHasRoleFilamentActionVisibility;
 
     public function setUp(): void
     {
@@ -182,7 +183,7 @@ class StandAssignmentsHistoryResourceTest extends BaseFilamentTestCase
                 'callsign' => 'BAW123',
                 'assigned_at' => Carbon::now(),
                 'type' => 'TEST',
-                'context' => [],
+                'context' => ['abc'],
             ]
         )->id;
     }
@@ -195,8 +196,19 @@ class StandAssignmentsHistoryResourceTest extends BaseFilamentTestCase
                 'callsign' => 'BAW123',
                 'assigned_at' => Carbon::now(),
                 'type' => 'TEST',
-                'context' => [],
+                'context' => ['abc'],
             ]
         );
+    }
+
+    public static function indexRoleProvider(): array
+    {
+        return [
+            'None' => [null, false],
+            'Contributor' => [RoleKeys::OPERATIONS_CONTRIBUTOR, true],
+            'DSG' => [RoleKeys::DIVISION_STAFF_GROUP, true],
+            'Web' => [RoleKeys::WEB_TEAM, true],
+            'Operations' => [RoleKeys::OPERATIONS_TEAM, true],
+        ];
     }
 }

--- a/tests/app/Policies/ReadOnlyWithRolePolicyTest.php
+++ b/tests/app/Policies/ReadOnlyWithRolePolicyTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace App\Policies;
+
+use App\BaseUnitTestCase;
+use App\Models\User\Role;
+use App\Models\User\RoleKeys;
+use App\Models\User\User;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class ReadOnlyWithRolePolicyTest extends BaseUnitTestCase
+{
+    private readonly ReadOnlyWithRolePolicy $policy;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->policy = $this->app->make(ReadOnlyWithRolePolicy::class);
+    }
+
+    #[DataProvider('dataProvider')]
+    public function testItManagesAccess(string $action, ?RoleKeys $role, bool $expected)
+    {
+        $user = User::factory()->create();
+        if ($role) {
+            $user->roles()->sync([Role::idFromKey($role)]);
+        }
+
+        $this->assertEquals($expected, $this->policy->$action($user));
+    }
+
+    public static function dataProvider(): array
+    {
+        return [
+            'View No Role' => ['view', null, false],
+            'View Operations Contributor' => ['view',  RoleKeys::OPERATIONS_CONTRIBUTOR, true],
+            'View Operations' => ['view', RoleKeys::OPERATIONS_TEAM, true],
+            'View Web' => ['view', RoleKeys::WEB_TEAM, true],
+            'View DSG' => ['view', RoleKeys::DIVISION_STAFF_GROUP, true],
+            'View Any No Role' => ['viewAny', null, false],
+            'View Any Operations Contributor' => ['viewAny',  RoleKeys::OPERATIONS_CONTRIBUTOR, true],
+            'View Any Operations' => ['viewAny', RoleKeys::OPERATIONS_TEAM, true],
+            'View Any Web' => ['viewAny', RoleKeys::WEB_TEAM, true],
+            'View Any DSG' => ['viewAny', RoleKeys::DIVISION_STAFF_GROUP, true],
+            'Update No Role' => ['update', null, false],
+            'Update Operations Contributor' => ['update',  RoleKeys::OPERATIONS_CONTRIBUTOR, false],
+            'Update Operations' => ['update', RoleKeys::OPERATIONS_TEAM, false],
+            'Update Web' => ['update', RoleKeys::WEB_TEAM, false],
+            'Update DSG' => ['update', RoleKeys::DIVISION_STAFF_GROUP, false],
+            'Create No Role' => ['create', null, false],
+            'Create Operations Contributor' => ['create',  RoleKeys::OPERATIONS_CONTRIBUTOR, false],
+            'Create Operations' => ['create', RoleKeys::OPERATIONS_TEAM, false],
+            'Create Web' => ['create', RoleKeys::WEB_TEAM, false],
+            'Create DSG' => ['create', RoleKeys::DIVISION_STAFF_GROUP, false],
+            'Delete No Role' => ['delete', null, false],
+            'Delete Operations Contributor' => ['delete',  RoleKeys::OPERATIONS_CONTRIBUTOR, false],
+            'Delete Operations' => ['delete', RoleKeys::OPERATIONS_TEAM, false],
+            'Delete Web' => ['delete', RoleKeys::WEB_TEAM, false],
+            'Delete DSG' => ['delete', RoleKeys::DIVISION_STAFF_GROUP, false],
+            'Delete Any No Role' => ['deleteAny', null, false],
+            'Delete Any Operations Contributor' => ['deleteAny',  RoleKeys::OPERATIONS_CONTRIBUTOR, false],
+            'Delete Any Operations' => ['deleteAny', RoleKeys::OPERATIONS_TEAM, false],
+            'Delete Any Web' => ['deleteAny', RoleKeys::WEB_TEAM, false],
+            'Delete Any DSG' => ['deleteAny', RoleKeys::DIVISION_STAFF_GROUP, false],
+            'Restore No Role' => ['restore', null, false],
+            'Restore Operations Contributor' => ['restore',  RoleKeys::OPERATIONS_CONTRIBUTOR, false],
+            'Restore Operations' => ['restore', RoleKeys::OPERATIONS_TEAM, false],
+            'Restore Web' => ['restore', RoleKeys::WEB_TEAM, false],
+            'Restore DSG' => ['restore', RoleKeys::DIVISION_STAFF_GROUP, false],
+            'Restore Any No Role' => ['restoreAny', null, false],
+            'Restore Any Operations Contributor' => ['restoreAny',  RoleKeys::OPERATIONS_CONTRIBUTOR, false],
+            'Restore Any Operations' => ['restoreAny', RoleKeys::OPERATIONS_TEAM, false],
+            'Restore Any Web' => ['restoreAny', RoleKeys::WEB_TEAM, false],
+            'Restore Any DSG' => ['restoreAny', RoleKeys::DIVISION_STAFF_GROUP, false],
+            'Force Delete No Role' => ['forceDelete', null, false],
+            'Force Delete Operations Contributor' => ['forceDelete',  RoleKeys::OPERATIONS_CONTRIBUTOR, false],
+            'Force Delete Operations' => ['forceDelete', RoleKeys::OPERATIONS_TEAM, false],
+            'Force Delete Web' => ['forceDelete', RoleKeys::WEB_TEAM, false],
+            'Force Delete DSG' => ['forceDelete', RoleKeys::DIVISION_STAFF_GROUP, false],
+            'Force Delete Any No Role' => ['forceDeleteAny', null, false],
+            'Force Delete Any Operations Contributor' => ['forceDeleteAny',  RoleKeys::OPERATIONS_CONTRIBUTOR, false],
+            'Force Delete Any Operations' => ['forceDeleteAny', RoleKeys::OPERATIONS_TEAM, false],
+            'Force Delete Any Web' => ['forceDeleteAny', RoleKeys::WEB_TEAM, false],
+            'Force Delete Any DSG' => ['forceDeleteAny', RoleKeys::DIVISION_STAFF_GROUP, false],
+            'Dissociate No Role' => ['dissociate', null, false],
+            'Dissociate Operations Contributor' => ['dissociate',  RoleKeys::OPERATIONS_CONTRIBUTOR, false],
+            'Dissociate Operations' => ['dissociate', RoleKeys::OPERATIONS_TEAM, false],
+            'Dissociate Any Web' => ['dissociate', RoleKeys::WEB_TEAM, false],
+            'Dissociate DSG' => ['dissociate', RoleKeys::DIVISION_STAFF_GROUP, false],
+            'Dissociate Any No Role' => ['dissociateAny', null, false],
+            'Dissociate Any Operations Contributor' => ['dissociateAny',  RoleKeys::OPERATIONS_CONTRIBUTOR, false],
+            'Dissociate Any Operations' => ['dissociateAny', RoleKeys::OPERATIONS_TEAM, false],
+            'Dissociate Any Any Web' => ['dissociateAny', RoleKeys::WEB_TEAM, false],
+            'Dissociate Any DSG' => ['dissociateAny', RoleKeys::DIVISION_STAFF_GROUP, false],
+            'Replicate No Role' => ['replicate', null, false],
+            'Replicate Operations Contributor' => ['replicate',  RoleKeys::OPERATIONS_CONTRIBUTOR, false],
+            'Replicate Operations' => ['replicate', RoleKeys::OPERATIONS_TEAM, false],
+            'Replicate Any Web' => ['replicate', RoleKeys::WEB_TEAM, false],
+            'Replicate DSG' => ['replicate', RoleKeys::DIVISION_STAFF_GROUP, false],
+
+            // Filament Special Roles
+            'Attach No Role' => ['attach', null, false],
+            'Attach Operations Contributor' => ['attach',  RoleKeys::OPERATIONS_CONTRIBUTOR, false],
+            'Attach Operations' => ['attach', RoleKeys::OPERATIONS_TEAM, false],
+            'Attach Web' => ['attach', RoleKeys::WEB_TEAM, false],
+            'Attach DSG' => ['attach', RoleKeys::DIVISION_STAFF_GROUP, false],
+            'Detach No Role' => ['detach', null, false],
+            'Detach Operations Contributor' => ['detach',  RoleKeys::OPERATIONS_CONTRIBUTOR, false],
+            'Detach Operations' => ['detach', RoleKeys::OPERATIONS_TEAM, false],
+            'Detach Web' => ['detach', RoleKeys::WEB_TEAM, false],
+            'Detach DSG' => ['detach', RoleKeys::DIVISION_STAFF_GROUP, false],
+            'Detach Any No Role' => ['detachAny', null, false],
+            'Detach Any Operations Contributor' => ['detachAny',  RoleKeys::OPERATIONS_CONTRIBUTOR, false],
+            'Detach Any Operations' => ['detachAny', RoleKeys::OPERATIONS_TEAM, false],
+            'Detach Any Web' => ['detachAny', RoleKeys::WEB_TEAM, false],
+            'Detach Anh DSG' => ['detachAny', RoleKeys::DIVISION_STAFF_GROUP, false],
+        ];
+    }
+}

--- a/tests/app/Services/Stand/StandAssignmentsHistoryServiceTest.php
+++ b/tests/app/Services/Stand/StandAssignmentsHistoryServiceTest.php
@@ -7,6 +7,7 @@ use App\Models\Stand\Stand;
 use App\Models\Stand\StandAssignment;
 use App\Models\Stand\StandAssignmentsHistory;
 use App\Models\User\User;
+use App\Models\Vatsim\NetworkAircraft;
 use App\Services\NetworkAircraftService;
 
 class StandAssignmentsHistoryServiceTest extends BaseFunctionalTestCase
@@ -51,7 +52,7 @@ class StandAssignmentsHistoryServiceTest extends BaseFunctionalTestCase
                 'stand_id' => 1,
             ]
         );
-        $this->service->createHistoryItem(new StandAssignmentContext($assignment, 'test', collect()));
+        $this->service->createHistoryItem(new StandAssignmentContext($assignment, 'test', collect(), NetworkAircraft::find('BAW123')));
         $this->assertDatabaseHas(
             'stand_assignments_history',
             [
@@ -69,6 +70,7 @@ class StandAssignmentsHistoryServiceTest extends BaseFunctionalTestCase
             'removed_assignments' => [],
             'occupied_stands' => [],
             'assigned_stands' => [],
+            'flightplan_remarks' => 'BAW123 Remarks',
         ];
         $context = StandAssignmentsHistory::latest()->first()->context;
         $this->assertEquals($expectedContext, $context);
@@ -110,7 +112,7 @@ class StandAssignmentsHistoryServiceTest extends BaseFunctionalTestCase
         $occupiedStand2 = Stand::factory()->create(['airfield_id' => 1]);
         $occupiedStand2->occupier()->sync(['BAW1002']);
 
-        $this->service->createHistoryItem(new StandAssignmentContext($assignment, 'test', $removedAssignments));
+        $this->service->createHistoryItem(new StandAssignmentContext($assignment, 'test', $removedAssignments, NetworkAircraft::find('BAW123')));
         $this->assertDatabaseHas(
             'stand_assignments_history',
             [
@@ -154,6 +156,7 @@ class StandAssignmentsHistoryServiceTest extends BaseFunctionalTestCase
                 '1L',
                 '251',
             ],
+            'flightplan_remarks' => 'BAW123 Remarks',
         ];
         $context = StandAssignmentsHistory::latest()->first()->context;
         $this->assertEquals($expectedContext, $context);
@@ -168,7 +171,7 @@ class StandAssignmentsHistoryServiceTest extends BaseFunctionalTestCase
                 'stand_id' => 1,
             ]
         );
-        $this->service->createHistoryItem(new StandAssignmentContext($assignment, 'test', collect()));
+        $this->service->createHistoryItem(new StandAssignmentContext($assignment, 'test', collect(), NetworkAircraft::find('BAW123')));
         $this->assertDatabaseHas(
             'stand_assignments_history',
             [
@@ -186,6 +189,7 @@ class StandAssignmentsHistoryServiceTest extends BaseFunctionalTestCase
             'removed_assignments' => [],
             'occupied_stands' => [],
             'assigned_stands' => [],
+            'flightplan_remarks' => 'BAW123 Remarks',
         ];
         $context = StandAssignmentsHistory::latest()->first()->context;
         $this->assertEquals($expectedContext, $context);
@@ -209,7 +213,7 @@ class StandAssignmentsHistoryServiceTest extends BaseFunctionalTestCase
                 'stand_id' => 1,
             ]
         );
-        $this->service->createHistoryItem(new StandAssignmentContext($assignment, 'test', collect()));
+        $this->service->createHistoryItem(new StandAssignmentContext($assignment, 'test', collect(), NetworkAircraft::find('BAW123')));
 
         $this->assertSoftDeleted($history->refresh());
         $this->assertSoftDeleted($history2->refresh());

--- a/tests/app/Services/Stand/StandAssignmentsHistoryServiceTest.php
+++ b/tests/app/Services/Stand/StandAssignmentsHistoryServiceTest.php
@@ -3,9 +3,11 @@
 namespace App\Services\Stand;
 
 use App\BaseFunctionalTestCase;
+use App\Models\Stand\Stand;
 use App\Models\Stand\StandAssignment;
 use App\Models\Stand\StandAssignmentsHistory;
 use App\Models\User\User;
+use App\Services\NetworkAircraftService;
 
 class StandAssignmentsHistoryServiceTest extends BaseFunctionalTestCase
 {
@@ -22,10 +24,12 @@ class StandAssignmentsHistoryServiceTest extends BaseFunctionalTestCase
         $history = StandAssignmentsHistory::create([
             'callsign' => 'BAW123',
             'stand_id' => 1,
+            'type' => 'test',
         ]);
         $history2 = StandAssignmentsHistory::create([
             'callsign' => 'BAW123',
             'stand_id' => 2,
+            'type' => 'test',
         ]);
         $assignment = StandAssignment::create(
             [
@@ -47,15 +51,106 @@ class StandAssignmentsHistoryServiceTest extends BaseFunctionalTestCase
                 'stand_id' => 1,
             ]
         );
-        $this->service->createHistoryItem($assignment);
+        $this->service->createHistoryItem(new StandAssignmentContext($assignment, 'test', collect()));
         $this->assertDatabaseHas(
             'stand_assignments_history',
             [
                 'callsign' => 'BAW123',
+                'type' => 'test',
                 'stand_id' => 1,
                 'user_id' => null,
+            ],
+        );
+
+        $expectedContext = [
+            'removed_assignments' => [],
+            'occupied_stands' => [],
+            'assigned_stands' => [],
+        ];
+        $context = StandAssignmentsHistory::latest()->first()->context;
+        $this->assertEquals($expectedContext, $context);
+    }
+
+    public function testItCreatesStandAssignmentHistoryWithContext()
+    {
+        $newStand = Stand::factory()->create(['airfield_id' => 1]);
+        $assignment = StandAssignment::create(
+            [
+                'callsign' => 'BAW123',
+                'stand_id' => $newStand->id,
             ]
         );
+
+        // Create some context to the assignment - stand assignments
+        NetworkAircraftService::createPlaceholderAircraft('BAW999');
+        NetworkAircraftService::createPlaceholderAircraft('BAW1000');
+        NetworkAircraftService::createPlaceholderAircraft('BAW1001');
+        NetworkAircraftService::createPlaceholderAircraft('BAW1002');
+        $existing1 = StandAssignment::create(
+            [
+                'callsign' => 'BAW999',
+                'stand_id' => 1,
+            ]
+        );
+        $existing2 = StandAssignment::create(
+            [
+                'callsign' => 'BAW1000',
+                'stand_id' => 2,
+            ]
+        );
+
+        $removedAssignments = collect([$existing1, $existing2]);
+
+        // Extra context - occupations
+        $occupiedStand = Stand::factory()->create(['airfield_id' => 1]);
+        $occupiedStand->occupier()->sync(['BAW1001']);
+        $occupiedStand2 = Stand::factory()->create(['airfield_id' => 1]);
+        $occupiedStand2->occupier()->sync(['BAW1002']);
+
+        $this->service->createHistoryItem(new StandAssignmentContext($assignment, 'test', $removedAssignments));
+        $this->assertDatabaseHas(
+            'stand_assignments_history',
+            [
+                'callsign' => 'BAW123',
+                'stand_id' => $newStand->id,
+                'type' => 'test',
+                'user_id' => null,
+            ],
+        );
+
+        // Assign a stand at another airfield to test this isn't in the response
+        $standAtAnotherAirfield = Stand::factory()->create();
+        NetworkAircraftService::createPlaceholderAircraft('BAW1003');
+        $standAtAnotherAirfield->assignment()->create(['callsign' => 'BAW1003']);
+
+        // Occupy a stand at another airfield to test this isn't in the response
+        $standAtAnotherAirfield2 = Stand::factory()->create();
+        NetworkAircraftService::createPlaceholderAircraft('BAW1004');
+        $standAtAnotherAirfield2->occupier()->sync(['BAW1004']);
+
+
+        $expectedContext = [
+            'removed_assignments' => [
+                [
+                    'callsign' => 'BAW999',
+                    'stand' => '1L',
+                ],
+                [
+                    'callsign' => 'BAW1000',
+                    'stand' => '251',
+                ],
+            ],
+            'occupied_stands' => [
+                $occupiedStand->identifier,
+                $occupiedStand2->identifier,
+            ],
+            'assigned_stands' => [
+                '1L',
+                '251',
+            ],
+        ];
+        $context = StandAssignmentsHistory::latest()->first()->context;
+        $this->assertEquals($expectedContext, $context);
     }
 
     public function testItCreatesStandAssignmentHistoryWithAUser()
@@ -67,15 +162,24 @@ class StandAssignmentsHistoryServiceTest extends BaseFunctionalTestCase
                 'stand_id' => 1,
             ]
         );
-        $this->service->createHistoryItem($assignment);
+        $this->service->createHistoryItem(new StandAssignmentContext($assignment, 'test', collect()));
         $this->assertDatabaseHas(
             'stand_assignments_history',
             [
                 'callsign' => 'BAW123',
                 'stand_id' => 1,
+                'type' => 'test',
                 'user_id' => self::ACTIVE_USER_CID,
             ]
         );
+
+        $expectedContext = [
+            'removed_assignments' => [],
+            'occupied_stands' => [],
+            'assigned_stands' => [],
+        ];
+        $context = StandAssignmentsHistory::latest()->first()->context;
+        $this->assertEquals($expectedContext, $context);
     }
 
     public function testCreatingAHistoryItemDeletesOtherHistory()
@@ -83,10 +187,12 @@ class StandAssignmentsHistoryServiceTest extends BaseFunctionalTestCase
         $history = StandAssignmentsHistory::create([
             'callsign' => 'BAW123',
             'stand_id' => 1,
+            'type' => 'test',
         ]);
         $history2 = StandAssignmentsHistory::create([
             'callsign' => 'BAW123',
             'stand_id' => 2,
+            'type' => 'test',
         ]);
         $assignment = StandAssignment::create(
             [
@@ -94,7 +200,7 @@ class StandAssignmentsHistoryServiceTest extends BaseFunctionalTestCase
                 'stand_id' => 1,
             ]
         );
-        $this->service->createHistoryItem($assignment);
+        $this->service->createHistoryItem(new StandAssignmentContext($assignment, 'test', collect()));
 
         $this->assertSoftDeleted($history->refresh());
         $this->assertSoftDeleted($history2->refresh());

--- a/tests/app/Services/Stand/StandAssignmentsHistoryServiceTest.php
+++ b/tests/app/Services/Stand/StandAssignmentsHistoryServiceTest.php
@@ -63,6 +63,9 @@ class StandAssignmentsHistoryServiceTest extends BaseFunctionalTestCase
         );
 
         $expectedContext = [
+            'aircraft_type' => 'B738',
+            'aircraft_departure_airfield' => 'EGKK',
+            'aircraft_arrival_airfield' => 'EGLL',
             'removed_assignments' => [],
             'occupied_stands' => [],
             'assigned_stands' => [],
@@ -130,6 +133,9 @@ class StandAssignmentsHistoryServiceTest extends BaseFunctionalTestCase
 
 
         $expectedContext = [
+            'aircraft_type' => 'B738',
+            'aircraft_departure_airfield' => 'EGKK',
+            'aircraft_arrival_airfield' => 'EGLL',
             'removed_assignments' => [
                 [
                     'callsign' => 'BAW999',
@@ -174,6 +180,9 @@ class StandAssignmentsHistoryServiceTest extends BaseFunctionalTestCase
         );
 
         $expectedContext = [
+            'aircraft_type' => 'B738',
+            'aircraft_departure_airfield' => 'EGKK',
+            'aircraft_arrival_airfield' => 'EGLL',
             'removed_assignments' => [],
             'occupied_stands' => [],
             'assigned_stands' => [],

--- a/tests/app/Services/Stand/StandAssignmentsHistoryServiceTest.php
+++ b/tests/app/Services/Stand/StandAssignmentsHistoryServiceTest.php
@@ -73,6 +73,7 @@ class StandAssignmentsHistoryServiceTest extends BaseFunctionalTestCase
             'assigned_stands' => [],
             'flightplan_remarks' => 'BAW123 Remarks',
             'requested_stand' => null,
+            'other_requested_stands' => [],
         ];
         $context = StandAssignmentsHistory::latest()->first()->context;
         $this->assertEquals($expectedContext, $context);
@@ -124,8 +125,11 @@ class StandAssignmentsHistoryServiceTest extends BaseFunctionalTestCase
         NetworkAircraftService::createPlaceholderAircraft('BAW1004');
         $standAtAnotherAirfield2->occupier()->sync(['BAW1004']);
 
-        // Create a stand request
+        // Create a stand request for us
         $standRequest = StandRequest::factory()->create(['user_id' => self::ACTIVE_USER_CID, 'callsign' => 'BAW123', 'stand_id' => $newStand->id]);
+
+        // Create another stand request for another user
+        StandRequest::factory()->create(['user_id' => 1203534, 'callsign' => 'BAW456', 'stand_id' => 1]);
 
         $this->service->createHistoryItem(new StandAssignmentContext($assignment, 'test', $removedAssignments, NetworkAircraft::find('BAW123')));
         $this->assertDatabaseHas(
@@ -162,6 +166,9 @@ class StandAssignmentsHistoryServiceTest extends BaseFunctionalTestCase
             ],
             'flightplan_remarks' => 'BAW123 Remarks',
             'requested_stand' => $standRequest->stand->identifier,
+            'other_requested_stands' => [
+                '1L',
+            ],
         ];
         $context = StandAssignmentsHistory::latest()->first()->context;
         $this->assertEquals($expectedContext, $context);
@@ -196,6 +203,7 @@ class StandAssignmentsHistoryServiceTest extends BaseFunctionalTestCase
             'assigned_stands' => [],
             'flightplan_remarks' => 'BAW123 Remarks',
             'requested_stand' => null,
+            'other_requested_stands' => [],
         ];
         $context = StandAssignmentsHistory::latest()->first()->context;
         $this->assertEquals($expectedContext, $context);

--- a/tests/app/Services/Stand/StandAssignmentsServiceTest.php
+++ b/tests/app/Services/Stand/StandAssignmentsServiceTest.php
@@ -8,7 +8,6 @@ use App\Events\StandUnassignedEvent;
 use App\Exceptions\Stand\StandNotFoundException;
 use App\Models\Stand\Stand;
 use App\Models\Stand\StandAssignment;
-use App\Models\Stand\StandAssignmentsHistory;
 use App\Models\Vatsim\NetworkAircraft;
 use Illuminate\Support\Facades\Event;
 use Mockery;
@@ -153,7 +152,8 @@ class StandAssignmentsServiceTest extends BaseFunctionalTestCase
                     $context->assignment->stand_id === 2 &&
                     $context->assignment->user_id === null &&
                     $context->assignmentType === 'test' &&
-                    $context->removedAssignments->isEmpty()
+                    $context->removedAssignments->isEmpty() &&
+                    $context->aircraft->callsign === 'BAW123'
                 )
             )
             ->once();
@@ -192,7 +192,8 @@ class StandAssignmentsServiceTest extends BaseFunctionalTestCase
                     $context->removedAssignments->isNotEmpty() &&
                     $context->removedAssignments->count() === 1 &&
                     $context->removedAssignments->first()->callsign === 'BAW456' &&
-                    $context->removedAssignments->first()->stand_id === 2
+                    $context->removedAssignments->first()->stand_id === 2 &&
+                    $context->aircraft->callsign === 'BAW123'
                 )
             )
             ->once();
@@ -257,7 +258,8 @@ class StandAssignmentsServiceTest extends BaseFunctionalTestCase
                     $context->removedAssignments->first()->callsign === 'BAW456' &&
                     $context->removedAssignments->first()->stand_id === 2 &&
                     $context->removedAssignments->last()->callsign === 'BAW789' &&
-                    $context->removedAssignments->last()->stand_id === 3
+                    $context->removedAssignments->last()->stand_id === 3 &&
+                    $context->aircraft->callsign === 'BAW123'
                 )
             )
             ->once();
@@ -265,7 +267,7 @@ class StandAssignmentsServiceTest extends BaseFunctionalTestCase
         $this->mockHistoryService->shouldReceive('deleteHistoryFor')
             ->with(Mockery::on(fn(StandAssignment $assignment): bool => $assignment->callsign === 'BAW456' && $assignment->stand_id === 2))
             ->once();
-            
+
         $this->mockHistoryService->shouldReceive('deleteHistoryFor')
             ->with(Mockery::on(fn(StandAssignment $assignment): bool => $assignment->callsign === 'BAW789' && $assignment->stand_id === 3))
             ->once();
@@ -320,7 +322,8 @@ class StandAssignmentsServiceTest extends BaseFunctionalTestCase
                     $context->assignment->stand_id === 2 &&
                     $context->assignment->user_id === null &&
                     $context->assignmentType === 'test' &&
-                    $context->removedAssignments->isEmpty()
+                    $context->removedAssignments->isEmpty() &&
+                    $context->aircraft->callsign === 'BAW123'
                 )
             )
             ->once();

--- a/tests/app/Services/Stand/StandAssignmentsServiceTest.php
+++ b/tests/app/Services/Stand/StandAssignmentsServiceTest.php
@@ -113,11 +113,11 @@ class StandAssignmentsServiceTest extends BaseFunctionalTestCase
         $this->mockHistoryService->shouldReceive('createHistoryItem')
             ->with(
                 Mockery::on(
-                    fn(StandAssignmentContext $context): bool => $context->assignment()->callsign === 'BAW123' &&
-                    $context->assignment()->stand_id === 2 &&
-                    $context->assignment()->user_id === null &&
-                    $context->assignmentType() === 'test' &&
-                    $context->removedAssignments()->isEmpty()
+                    fn(StandAssignmentContext $context): bool => $context->assignment->callsign === 'BAW123' &&
+                    $context->assignment->stand_id === 2 &&
+                    $context->assignment->user_id === null &&
+                    $context->assignmentType === 'test' &&
+                    $context->removedAssignments->isEmpty()
                 )
             )
             ->once();
@@ -149,11 +149,11 @@ class StandAssignmentsServiceTest extends BaseFunctionalTestCase
         $this->mockHistoryService->shouldReceive('createHistoryItem')
             ->with(
                 Mockery::on(
-                    fn(StandAssignmentContext $context): bool => $context->assignment()->callsign === 'BAW123' &&
-                    $context->assignment()->stand_id === 2 &&
-                    $context->assignment()->user_id === null &&
-                    $context->assignmentType() === 'test' &&
-                    $context->removedAssignments()->isEmpty()
+                    fn(StandAssignmentContext $context): bool => $context->assignment->callsign === 'BAW123' &&
+                    $context->assignment->stand_id === 2 &&
+                    $context->assignment->user_id === null &&
+                    $context->assignmentType === 'test' &&
+                    $context->removedAssignments->isEmpty()
                 )
             )
             ->once();
@@ -185,14 +185,14 @@ class StandAssignmentsServiceTest extends BaseFunctionalTestCase
         $this->mockHistoryService->shouldReceive('createHistoryItem')
             ->with(
                 Mockery::on(
-                    fn(StandAssignmentContext $context): bool => $context->assignment()->callsign === 'BAW123' &&
-                    $context->assignment()->stand_id === 2 &&
-                    $context->assignment()->user_id === null &&
-                    $context->assignmentType() === 'test' &&
-                    $context->removedAssignments()->isNotEmpty() &&
-                    $context->removedAssignments()->count() === 1 &&
-                    $context->removedAssignments()->first()->callsign === 'BAW456' &&
-                    $context->removedAssignments()->first()->stand_id === 2
+                    fn(StandAssignmentContext $context): bool => $context->assignment->callsign === 'BAW123' &&
+                    $context->assignment->stand_id === 2 &&
+                    $context->assignment->user_id === null &&
+                    $context->assignmentType === 'test' &&
+                    $context->removedAssignments->isNotEmpty() &&
+                    $context->removedAssignments->count() === 1 &&
+                    $context->removedAssignments->first()->callsign === 'BAW456' &&
+                    $context->removedAssignments->first()->stand_id === 2
                 )
             )
             ->once();
@@ -248,16 +248,16 @@ class StandAssignmentsServiceTest extends BaseFunctionalTestCase
         $this->mockHistoryService->shouldReceive('createHistoryItem')
             ->with(
                 Mockery::on(
-                    fn(StandAssignmentContext $context): bool => $context->assignment()->callsign === 'BAW123' &&
-                    $context->assignment()->stand_id === 2 &&
-                    $context->assignment()->user_id === null &&
-                    $context->assignmentType() === 'test' &&
-                    $context->removedAssignments()->isNotEmpty() &&
-                    $context->removedAssignments()->count() === 2 &&
-                    $context->removedAssignments()->first()->callsign === 'BAW456' &&
-                    $context->removedAssignments()->first()->stand_id === 2 &&
-                    $context->removedAssignments()->last()->callsign === 'BAW789' &&
-                    $context->removedAssignments()->last()->stand_id === 3
+                    fn(StandAssignmentContext $context): bool => $context->assignment->callsign === 'BAW123' &&
+                    $context->assignment->stand_id === 2 &&
+                    $context->assignment->user_id === null &&
+                    $context->assignmentType === 'test' &&
+                    $context->removedAssignments->isNotEmpty() &&
+                    $context->removedAssignments->count() === 2 &&
+                    $context->removedAssignments->first()->callsign === 'BAW456' &&
+                    $context->removedAssignments->first()->stand_id === 2 &&
+                    $context->removedAssignments->last()->callsign === 'BAW789' &&
+                    $context->removedAssignments->last()->stand_id === 3
                 )
             )
             ->once();
@@ -316,11 +316,11 @@ class StandAssignmentsServiceTest extends BaseFunctionalTestCase
         $this->mockHistoryService->shouldReceive('createHistoryItem')
             ->with(
                 Mockery::on(
-                    fn(StandAssignmentContext $context): bool => $context->assignment()->callsign === 'BAW123' &&
-                    $context->assignment()->stand_id === 2 &&
-                    $context->assignment()->user_id === null &&
-                    $context->assignmentType() === 'test' &&
-                    $context->removedAssignments()->isEmpty()
+                    fn(StandAssignmentContext $context): bool => $context->assignment->callsign === 'BAW123' &&
+                    $context->assignment->stand_id === 2 &&
+                    $context->assignment->user_id === null &&
+                    $context->assignmentType === 'test' &&
+                    $context->removedAssignments->isEmpty()
                 )
             )
             ->once();

--- a/tests/app/Services/Stand/StandRequestServiceTest.php
+++ b/tests/app/Services/Stand/StandRequestServiceTest.php
@@ -58,4 +58,23 @@ class StandRequestServiceTest extends BaseFunctionalTestCase
 
         $this->assertNull($this->service->activeRequestForAircraft($aircraft));
     }
+
+    public function testItReturnsAllActiveReservationsForAnAirfield()
+    {
+        // Will be returned
+        $activeRequest1 = StandRequest::factory()->create(['user_id' => 1203533, 'callsign' => 'BAW123', 'requested_time' => Carbon::now()->addMinutes(10), 'stand_id' => 1]);
+        $activeRequest2 = StandRequest::factory()->create(['user_id' => 1203534, 'callsign' => 'BAW456', 'requested_time' => Carbon::now()->addMinutes(10), 'stand_id' => 2]);
+
+        // Wont be returned, not active
+        StandRequest::factory()->create(['user_id' => 1203535, 'callsign' => 'BAW789', 'requested_time' => Carbon::now()->subMinutes(90), 'stand_id' => 1]);
+
+        // Wont be returned, deleted
+        StandRequest::factory()->create(['user_id' => 1203535, 'callsign' => 'BAW123', 'requested_time' => Carbon::now()->addMinutes(10), 'stand_id' => 1])->delete();
+
+        // Wont be returned, wrong airfield
+        StandRequest::factory()->create(['user_id' => 1203535, 'callsign' => 'BAW456', 'requested_time' => Carbon::now()->addMinutes(10), 'stand_id' => 3]);
+
+        $requests = $this->service->allActiveStandRequestsForAirfield('EGLL');
+        $this->assertEquals([$activeRequest1->id, $activeRequest2->id], $requests->pluck('id')->toArray());
+    }
 }

--- a/tests/app/Services/Stand/StandRequestServiceTest.php
+++ b/tests/app/Services/Stand/StandRequestServiceTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Services\Stand;
+
+use App\BaseFunctionalTestCase;
+use App\Models\Stand\StandRequest;
+use App\Models\Vatsim\NetworkAircraft;
+use Carbon\Carbon;
+
+class StandRequestServiceTest extends BaseFunctionalTestCase
+{
+
+    private readonly StandRequestService $service;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->service = $this->app->make(StandRequestService::class);
+    }
+
+    public function testItReturnsActiveRequestForAircraft()
+    {
+        $request = StandRequest::factory()->create(['user_id' => 1203533, 'callsign' => 'BAW123']);
+        $aircraft = NetworkAircraft::find('BAW123');
+
+        $this->assertEquals($request->id, $this->service->activeRequestForAircraft($aircraft)->id);
+    }
+
+    public function testItReturnsNullIfRequestIsForDifferentCallsign()
+    {
+        StandRequest::factory()->create(['user_id' => 1203533, 'callsign' => 'BAW456']);
+        $aircraft = NetworkAircraft::find('BAW123');
+
+        $this->assertNull($this->service->activeRequestForAircraft($aircraft));
+    }
+
+    public function testItReturnsNullIfRequestIsForDifferentCid()
+    {
+        StandRequest::factory()->create(['user_id' => 1203534, 'callsign' => 'BAW123']);
+        $aircraft = NetworkAircraft::find('BAW123');
+
+        $this->assertNull($this->service->activeRequestForAircraft($aircraft));
+    }
+
+    public function testItReturnsNullIfNoActiveRequestForAircraft()
+    {
+        StandRequest::factory()->create(['user_id' => 1203533, 'callsign' => 'BAW123', 'requested_time' => Carbon::now()->subMinutes(30)]);
+        $aircraft = NetworkAircraft::find('BAW123');
+
+        $this->assertNull($this->service->activeRequestForAircraft($aircraft));
+    }
+
+    public function testItReturnsNullIfNoCid()
+    {
+        StandRequest::factory()->create(['user_id' => 1203533, 'callsign' => 'BAW123']);
+        $aircraft = NetworkAircraft::find('BAW123');
+        $aircraft->cid = null;
+
+        $this->assertNull($this->service->activeRequestForAircraft($aircraft));
+    }
+}


### PR DESCRIPTION
- Adds "context" to stand assignment history items that includes information at the time of the assignment, e.g. occupied stands, aircraft information, requested stands.
- Adds a filament resource, accessible only to ops contributors and above, that allows this information to be viewed.