### PR TITLE
feat: 8.33KHz controller frequencies

### DIFF
--- a/app/Rules/Controller/ControllerPositionFrequency.php
+++ b/app/Rules/Controller/ControllerPositionFrequency.php
@@ -15,7 +15,7 @@ class ControllerPositionFrequency implements InvokableRule
             !is_string($value) ||
             empty($value) ||
             !preg_match(self::FREQUENCY_REGEX, $value, $matches) ||
-            (int) $matches[1] % 25 !== 0
+            (int) $matches[1] % 5 !== 0
         ) {
             $fail('validation.frequency')->translate();
         }

--- a/tests/app/Filament/ControllerPositionResourceTest.php
+++ b/tests/app/Filament/ControllerPositionResourceTest.php
@@ -80,6 +80,33 @@ class ControllerPositionResourceTest extends BaseFilamentTestCase
         );
     }
 
+    public function testItCreatesAControllerPositionWith8Point33Spacing()
+    {
+        Livewire::test(ControllerPositionResource\Pages\CreateControllerPosition::class)
+            ->set('data.callsign', 'LON_W_CTR')
+            ->set('data.description', 'London West (Bandbox)')
+            ->set('data.frequency', '126.080')
+            ->set('data.requests_departure_releases', true)
+            ->set('data.receives_departure_releases', true)
+            ->set('data.sends_prenotes', false)
+            ->set('data.receives_prenotes', true)
+            ->call('create')
+            ->assertHasNoErrors();
+
+        $this->assertDatabaseHas(
+            'controller_positions',
+            [
+                'callsign' => 'LON_W_CTR',
+                'description' => 'London West (Bandbox)',
+                'frequency' => '126.080',
+                'requests_departure_releases' => 1,
+                'receives_departure_releases' => 1,
+                'sends_prenotes' => 0,
+                'receives_prenotes' => 1,
+            ]
+        );
+    }
+
     public function testItDoesntCreateAPositionDuplicateCallsign()
     {
         Livewire::test(ControllerPositionResource\Pages\CreateControllerPosition::class)

--- a/tests/app/Rules/Controller/ControllerPositionFrequencyTest.php
+++ b/tests/app/Rules/Controller/ControllerPositionFrequencyTest.php
@@ -39,7 +39,6 @@ class ControllerPositionFrequencyTest extends BaseUnitTestCase
             'Only two DP' => ['123.12', false],
             'Too long' => ['129.4200', false],
             'Too long two' => ['129.4205', false],
-            'Old frequencies' => ['129.420', false],
             'Not 25KHz Spaced' => ['129.133', false],
             '25KHz Zero' => ['129.000', true],
             '25KHz 25' => ['129.025', true],
@@ -49,6 +48,11 @@ class ControllerPositionFrequencyTest extends BaseUnitTestCase
             '25KHz 25 Two' => ['118.425', true],
             '25KHz 50 Two' => ['118.450', true],
             '25KHz 75 Two' => ['118.475', true],
+            '8.33KHz Zero' => ['129.000', true],
+            '8.33KHz LON_W' => ['118.480', true],
+            '8.33KHz EGLL_N_APP' => ['119.730', true],
+            '8.33KHz EGSS_APP' => ['123.805', true],
+            '8.33KHz EGGP_TWR' => ['126.355', true],
         ];
     }
 }


### PR DESCRIPTION
Updates frequency validation to allow controller position frequencies with 8.33KHz spacing in preparation for the trial.

https://community.vatsim.uk/topic/38977-833khz-trial-uk-frequency-changes-phase-1/