### PR TITLE
fix: arbitary stand predictor departure airfield

### DIFF
--- a/app/Http/Livewire/StandPredictorForm.php
+++ b/app/Http/Livewire/StandPredictorForm.php
@@ -4,6 +4,7 @@ namespace App\Http\Livewire;
 
 use App\Filament\Helpers\SelectOptions;
 use App\Models\Airfield\Airfield;
+use App\Rules\Airfield\AirfieldIcao;
 use App\Services\AirlineService;
 use Filament\Forms\Components\Grid;
 use Filament\Forms\Components\Select;
@@ -42,11 +43,11 @@ class StandPredictorForm extends Component implements HasForms
                         ->options(SelectOptions::aircraftTypes())
                         ->required()
                         ->searchable(),
-                    Select::make('departureAirfield')
+                    TextInput::make('departureAirfield')
                         ->label('Departure Airfield')
-                        ->options(Airfield::all()->mapWithKeys(fn ($airfield) => [$airfield->code => $airfield->code]))
-                        ->required()
-                        ->searchable(),
+                        ->rule(new AirfieldIcao())
+                        ->alpha()
+                        ->required(),
                     Select::make('arrivalAirfield')
                         ->label('Arrival Airfield')
                         ->options(Airfield::all()->mapWithKeys(fn ($airfield) => [$airfield->code => $airfield->code]))
@@ -58,6 +59,9 @@ class StandPredictorForm extends Component implements HasForms
 
     public function submit(): void
     {
+        // Convert the callsign to uppercase before validating it.
+        $this->callsign = strtoupper($this->callsign);
+
         $this->form->validate();
         $this->emit('standPredictorFormSubmitted', [
             'callsign' => $this->callsign,

--- a/tests/app/Http/Livewire/StandPredictorFormTest.php
+++ b/tests/app/Http/Livewire/StandPredictorFormTest.php
@@ -32,6 +32,25 @@ class StandPredictorFormTest extends BaseFilamentTestCase
             ]);
     }
 
+    public function testItSubmitsLowercaseDepartureAirfield()
+    {
+        Livewire::test(StandPredictorForm::class)
+            ->set('callsign', 'BAW999')
+            ->set('aircraftType', 1)
+            ->set('departureAirfield', 'egkk')
+            ->set('arrivalAirfield', 'EGLL')
+            ->call('submit')
+            ->assertHasNoErrors()
+            ->assertEmitted('standPredictorFormSubmitted', [
+                'callsign' => 'BAW999',
+                'cid' => 1203533,
+                'aircraft_id' => 1,
+                'airline_id' => 1,
+                'planned_depairport' => 'EGKK',
+                'planned_destairport' => 'EGLL',
+            ]);
+    }
+
     public function testItDoesntSubmitIfNoCallsign()
     {
         Livewire::test(StandPredictorForm::class)
@@ -59,6 +78,17 @@ class StandPredictorFormTest extends BaseFilamentTestCase
         Livewire::test(StandPredictorForm::class)
             ->set('callsign', 'BAW123')
             ->set('arrivalAirfield', 'EGLL')
+            ->call('submit')
+            ->assertHasErrors(['departureAirfield'])
+            ->assertNotEmitted('standPredictorFormSubmitted');
+    }
+
+    public function testItDoesntSubmitIfDepartureAirfieldNotIcao()
+    {
+        Livewire::test(StandPredictorForm::class)
+            ->set('callsign', 'BAW123')
+            ->set('arrivalAirfield', 'EGLL')
+            ->set('departureAirfield', '1234X')
             ->call('submit')
             ->assertHasErrors(['departureAirfield'])
             ->assertNotEmitted('standPredictorFormSubmitted');


### PR DESCRIPTION
Allows an arbitrary icao code to be specified rather than one from the fixed airport list.

Fixes #1412