### PR TITLE
Acars rate limiting

### DIFF
--- a/app/Acars/Provider/HoppieAcarsProvider.php
+++ b/app/Acars/Provider/HoppieAcarsProvider.php
@@ -55,7 +55,7 @@ class HoppieAcarsProvider implements AcarsProviderInterface
     {
         Cache::forever(
             self::ONLINE_CALLSIGNS_CACHE_KEY,
-            fn() => $this->fetchOnlineCallsigns()
+            $this->fetchOnlineCallsigns()
         );
     }
 

--- a/app/Acars/Provider/HoppieAcarsProvider.php
+++ b/app/Acars/Provider/HoppieAcarsProvider.php
@@ -4,6 +4,7 @@ namespace App\Acars\Provider;
 
 use App\Acars\Exception\AcarsRequestException;
 use App\Acars\Message\Telex\TelexMessageInterface;
+use App\Jobs\Acars\SendTelex;
 use App\Models\Acars\AcarsMessage;
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Collection;
@@ -15,29 +16,46 @@ use Illuminate\Support\Str;
 class HoppieAcarsProvider implements AcarsProviderInterface
 {
     private const ONLINE_CALLSIGNS_CACHE_KEY = 'HOPPIE_ACARS_ONLINE_CALLSIGNS';
-    private const ONLINE_CALLSIGNS_CACHE_DURATION_SECONDS = 120;
     private const VATUK_STATION_IDENTIFIER = 'VATSIMUK';
 
+    /**
+     * Dispatches a job to send a telex message. We dispatch a job because we need to avoid
+     * Hoppie rate limiting.
+     *
+     * @param TelexMessageInterface $message
+     * @return void
+     */
     public function sendTelex(TelexMessageInterface $message): void
     {
-        if ($this->getOnlineCallsigns()->doesntContain($message->getTarget())) {
+        if (!$this->getOnlineCallsigns()->contains($message->getTarget())) {
             return;
         }
 
+        SendTelex::dispatch($message);
+    }
+
+    /**
+     * Used by the SendTelex job to send a telex message. This method is intended for internal use and
+     * is not exposed on the interface.
+     */
+    public function sendTelexMessage(TelexMessageInterface $message): void
+    {
         $this->makeRequest('telex', $message->getTarget(), $message->getBody());
     }
 
     private function getOnlineCallsigns(): Collection
     {
-        return Cache::remember(
+        return Cache::get(
             self::ONLINE_CALLSIGNS_CACHE_KEY,
-            self::ONLINE_CALLSIGNS_CACHE_DURATION_SECONDS,
-            function () {
-                $responseBody = $this->getResponseBody(
-                    $this->makeRequest('ping', self::VATUK_STATION_IDENTIFIER, 'ALL-CALLSIGNS')
-                );
-                return collect($responseBody === '' ? [] : explode(' ', $responseBody));
-            }
+            collect()
+        );
+    }
+
+    public function setOnlineCallsigns(): void
+    {
+        Cache::forever(
+            self::ONLINE_CALLSIGNS_CACHE_KEY,
+            fn() => $this->fetchOnlineCallsigns()
         );
     }
 
@@ -49,11 +67,12 @@ class HoppieAcarsProvider implements AcarsProviderInterface
                 config('acars.hoppie.url'),
                 $message
             ),
-            function (Response $response) use ($message) {
+            function (Response $response) use ($message)
+            {
                 $success = $this->responseSuccessful($response);
                 $messageWithoutLogon = array_filter(
                     $message,
-                    fn (string $key) => $key !== 'logon',
+                    fn(string $key) => $key !== 'logon',
                     ARRAY_FILTER_USE_KEY
                 );
 
@@ -92,5 +111,13 @@ class HoppieAcarsProvider implements AcarsProviderInterface
     private function responseSuccessful(Response $response): bool
     {
         return $response->successful() && Str::substr($response, 0, 2) === 'ok';
+    }
+
+    private function fetchOnlineCallsigns(): Collection
+    {
+        $responseBody = $this->getResponseBody(
+            $this->makeRequest('ping', self::VATUK_STATION_IDENTIFIER, 'ALL-CALLSIGNS')
+        );
+        return collect($responseBody === '' ? [] : explode(' ', $responseBody));
     }
 }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -22,6 +22,7 @@ use App\Console\Commands\UpdateVatsimNetworkData;
 use App\Console\Commands\UserAdminCreate;
 use App\Console\Commands\UserCreate;
 use App\Console\Commands\WakeCategoriesImport;
+use App\Jobs\Acars\UpdateOnlineCallsigns;
 use Bugsnag\BugsnagLaravel\Commands\DeployCommand as BugsnagDeployCommand;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
@@ -99,6 +100,7 @@ class Kernel extends ConsoleKernel
         $schedule->command('plugin-events:clean')->everyTenMinutes()->doNotMonitor();
         $schedule->command('metars:update')->everyMinute();
         $schedule->command('database:check-table-updates')->everyMinute();
+        $schedule->job(UpdateOnlineCallsigns::class)->everyTwoMinutes()->doNotMonitor();
     }
 
     protected function bootstrappers()

--- a/app/Jobs/Acars/SendTelex.php
+++ b/app/Jobs/Acars/SendTelex.php
@@ -23,7 +23,7 @@ class SendTelex implements ShouldQueue
 
     public function handle(HoppieAcarsProvider $hoppie): void
     {
-        $hoppie->makeRequest('telex', $this->telex->getTarget(), $this->telex->getBody());
+        $hoppie->sendTelexMessage($this->telex);
     }
 
     public function middleware(): array

--- a/app/Jobs/Acars/SendTelex.php
+++ b/app/Jobs/Acars/SendTelex.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Jobs\Acars;
+
+use App\Acars\Message\Telex\TelexMessageInterface;
+use App\Acars\Provider\HoppieAcarsProvider;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\Middleware\RateLimited;
+use Illuminate\Queue\SerializesModels;
+
+class SendTelex implements ShouldQueue
+{
+    use Queueable, Dispatchable, SerializesModels;
+
+    private TelexMessageInterface $telex;
+
+    public function __construct(TelexMessageInterface $telex)
+    {
+        $this->telex = $telex;
+    }
+
+    public function handle(HoppieAcarsProvider $hoppie): void
+    {
+        $hoppie->makeRequest('telex', $this->telex->getTarget(), $this->telex->getBody());
+    }
+
+    public function middleware(): array
+    {
+        return [new RateLimited('hoppie')];
+    }
+}

--- a/app/Jobs/Acars/UpdateOnlineCallsigns.php
+++ b/app/Jobs/Acars/UpdateOnlineCallsigns.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Jobs\Acars;
+
+use App\Acars\Provider\HoppieAcarsProvider;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\Middleware\RateLimited;
+use Illuminate\Queue\SerializesModels;
+
+class UpdateOnlineCallsigns implements ShouldQueue
+{
+    use Queueable, Dispatchable, SerializesModels;
+
+    public function handle(HoppieAcarsProvider $hoppie): void
+    {
+        $hoppie->setOnlineCallsigns();
+    }
+
+    public function middleware(): array
+    {
+        return [new RateLimited('hoppie')];
+    }
+}

--- a/tests/app/Acars/Provider/HoppieAcarsProviderTest.php
+++ b/tests/app/Acars/Provider/HoppieAcarsProviderTest.php
@@ -143,14 +143,14 @@ class HoppieAcarsProviderTest extends BaseFunctionalTestCase
         Http::fake(
             [
                 config('acars.hoppie.url') => Http::response(
-                    'ok {callsigns=BAW123,BAW456}'
+                    'ok {BAW123 BAW456}'
                 ),
             ]
         );
 
         $this->provider->setOnlineCallsigns();
         $this->assertEquals(
-            ['BAW123', 'BAW456'],
+            collect(['BAW123', 'BAW456']),
             Cache::get(self::CACHE_KEY)
         );
     }
@@ -161,14 +161,14 @@ class HoppieAcarsProviderTest extends BaseFunctionalTestCase
         Http::fake(
             [
                 config('acars.hoppie.url') => Http::response(
-                    'ok {callsigns=BAW123,BAW456}'
+                    'ok {BAW123 BAW456}'
                 ),
             ]
         );
 
         $this->provider->setOnlineCallsigns();
         $this->assertEquals(
-            ['BAW123', 'BAW456'],
+            collect(['BAW123', 'BAW456']),
             Cache::get(self::CACHE_KEY)
         );
     }

--- a/tests/app/Jobs/Acars/SendTelexTest.php
+++ b/tests/app/Jobs/Acars/SendTelexTest.php
@@ -5,6 +5,7 @@ namespace App\Jobs\Acars;
 use App\Acars\Message\Telex\TelexMessageInterface;
 use App\Acars\Provider\HoppieAcarsProvider;
 use App\BaseUnitTestCase;
+use Illuminate\Queue\Middleware\RateLimited;
 use Mockery;
 
 class SendTelexTest extends BaseUnitTestCase

--- a/tests/app/Jobs/Acars/SendTelexTest.php
+++ b/tests/app/Jobs/Acars/SendTelexTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Jobs\Acars;
+
+use App\Acars\Message\Telex\TelexMessageInterface;
+use App\Acars\Provider\HoppieAcarsProvider;
+use App\BaseUnitTestCase;
+use Mockery;
+
+class SendTelexTest extends BaseUnitTestCase
+{
+    public function testItSendsATelex()
+    {
+        $hoppieProviderMock = Mockery::mock(HoppieAcarsProvider::class);
+        $telexMessage = Mockery::mock(TelexMessageInterface::class);
+
+        $hoppieProviderMock->shouldReceive('sendTelexMessage')
+            ->with($telexMessage)
+            ->once();
+
+        $job = new SendTelex($telexMessage);
+        $job->handle($hoppieProviderMock);
+    }
+
+    public function testItIsRateLimited()
+    {
+        $job = new UpdateOnlineCallsigns();
+        $this->assertEquals([new RateLimited('hoppie')], $job->middleware());
+    }
+}

--- a/tests/app/Jobs/Acars/UpdateOnlineCallsignsTest.php
+++ b/tests/app/Jobs/Acars/UpdateOnlineCallsignsTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Jobs\Acars;
+
+use App\Acars\Provider\HoppieAcarsProvider;
+use App\BaseUnitTestCase;
+use Illuminate\Queue\Middleware\RateLimited;
+use Mockery;
+
+class UpdateOnlineCallsignsTest extends BaseUnitTestCase
+{
+    public function testItSetsOnlineCallsigns()
+    {
+        $hoppieProviderMock = Mockery::mock(HoppieAcarsProvider::class);
+        $hoppieProviderMock->shouldReceive('setOnlineCallsigns')->once();
+
+        $job = new UpdateOnlineCallsigns();
+        $job->handle($hoppieProviderMock);
+    }
+
+    public function testItIsRateLimited()
+    {
+        $job = new UpdateOnlineCallsigns();
+        $this->assertEquals([new RateLimited('hoppie')], $job->middleware());
+    }
+}


### PR DESCRIPTION
Hoppie recently introduced a change that limits our interactions with his server. At the time of writing, this is limited to at most one request every 10 seconds. This is a problem for us as we check if aircraft are online and then if so, send the ACARS message (two requests), which violates the rate limit (even if we don't do it very often).

This change introduces two new jobs: updating the online ACARS callsigns (and caching them) as well as sending telex messages. These jobs share a rate limiter of one every 12 seconds. This should prevent us from hitting the rate limit. A delay is not ideal, but given that we currently make around 75 ACARS requests per day (including who's online pings), we shouldn't  be seeing any backpressure on the queue.