### PR TITLE
Fixes #1404 - Stand assignments 'locked' after landing

### DIFF
--- a/app/Models/Vatsim/NetworkAircraft.php
+++ b/app/Models/Vatsim/NetworkAircraft.php
@@ -17,7 +17,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Location\Coordinate;
-use Location\Distance\Vincenty;
 use Location\Distance\Haversine;
 
 class NetworkAircraft extends Model

--- a/app/Models/Vatsim/NetworkAircraft.php
+++ b/app/Models/Vatsim/NetworkAircraft.php
@@ -17,6 +17,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Location\Coordinate;
+use Location\Distance\Vincenty;
+use Location\Distance\Haversine;
 
 class NetworkAircraft extends Model
 {
@@ -167,5 +169,24 @@ class NetworkAircraft extends Model
     public function aircraft(): BelongsTo
     {
         return $this->belongsTo(Aircraft::class);
+    }
+
+    public function isNearDestination(float $thresholdNauticalMiles = 5.0): bool
+    {
+        if (!$this->destinationAirfield?->latitude || !$this->destinationAirfield?->longitude) {
+            return false;
+        }
+
+        $distanceToAirfieldInNm = LocationService::metersToNauticalMiles(
+            $this->latLong->getDistance($this->coordinate, new Haversine())
+        );
+
+        return $distanceToAirfieldInNm <= $thresholdNauticalMiles;
+    }
+
+    public function hasLanded(): bool
+    {
+        $isOnGround = $this->groundSpeed < 50;
+        return $isOnGround && $this->isNearDestination();
     }
 }


### PR DESCRIPTION
Fixes #1404

I know this issue was opened ages ago so I'm not sure if it's even wanted but I wanted to get some experience at making an edit to the API so I figured might as well try this one. 

I've added a function to the ```Network Aircraft``` model to find if its landed at it's destination airport. When there is a conflicting assignment, it checks if the aircraft has landed and if it has it wont delete the assignment. 

This does raise the issue, that the aircraft is now assigned to a stand that another aircraft occupies. However, there is no longer confusion with the stand changing unexpectedly after a taxi instruction has been given. 
