### PR TITLE
Add Codecov token to upload coverage report

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -174,6 +174,7 @@ jobs:
         uses: codecov/codecov-action@v6
         with:
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   trigger-release:
     name: Trigger Release


### PR DESCRIPTION
Fixes #1843 

Just requires the Token to be added REPO side

secrets.CODECOV_TOKEN