### PR TITLE
feat: replace stand used for allocation flag with allocation status

### DIFF
--- a/app/Allocator/Stand/SelectsFromSizeAppropriateAvailableStands.php
+++ b/app/Allocator/Stand/SelectsFromSizeAppropriateAvailableStands.php
@@ -28,7 +28,7 @@ trait SelectsFromSizeAppropriateAvailableStands
             $query->where('code', $aircraft->planned_destairport);
         })
             ->sizeAppropriate($aircraft->aircraft)
-            ->open()
+            ->allocationOpen()
             ->select('stands.*');
     }
 }

--- a/app/Allocator/Stand/SelectsFromSizeAppropriateAvailableStands.php
+++ b/app/Allocator/Stand/SelectsFromSizeAppropriateAvailableStands.php
@@ -18,7 +18,7 @@ trait SelectsFromSizeAppropriateAvailableStands
             $query->where('code', $aircraft->planned_destairport);
         })
             ->sizeAppropriate($aircraft->aircraft)
-            ->available()
+            ->availableForArrival()
             ->select('stands.*');
     }
 
@@ -28,7 +28,7 @@ trait SelectsFromSizeAppropriateAvailableStands
             $query->where('code', $aircraft->planned_destairport);
         })
             ->sizeAppropriate($aircraft->aircraft)
-            ->notClosed()
+            ->open()
             ->select('stands.*');
     }
 }

--- a/app/Filament/Helpers/SelectOptions.php
+++ b/app/Filament/Helpers/SelectOptions.php
@@ -173,7 +173,7 @@ class SelectOptions
             self::airfieldStandsCacheKey($airfield),
             fn (): Collection => Stand::with('airfield')
                 ->where('airfield_id', $airfield->id)
-                ->notClosed()
+                ->notUnavailable()
                 ->get()
                 ->mapWithKeys(fn (Stand $stand): array => [$stand->id => $stand->airfieldIdentifier])
         );

--- a/app/Filament/Resources/Stands/Pages/CreateStand.php
+++ b/app/Filament/Resources/Stands/Pages/CreateStand.php
@@ -3,16 +3,9 @@
 namespace App\Filament\Resources\Stands\Pages;
 
 use App\Filament\Resources\Stands\StandResource;
-use Carbon\Carbon;
 use Filament\Resources\Pages\CreateRecord;
 
 class CreateStand extends CreateRecord
 {
     protected static string $resource = StandResource::class;
-
-    public function mutateFormDataBeforeCreate(array $data): array
-    {
-        $data['closed_at'] = $data['closed_at'] ? null : Carbon::now();
-        return $data;
-    }
 }

--- a/app/Filament/Resources/Stands/Pages/EditStand.php
+++ b/app/Filament/Resources/Stands/Pages/EditStand.php
@@ -4,7 +4,6 @@ namespace App\Filament\Resources\Stands\Pages;
 
 use Filament\Actions\DeleteAction;
 use App\Filament\Resources\Stands\StandResource;
-use Carbon\Carbon;
 use Filament\Pages\Actions;
 use Filament\Resources\Pages\EditRecord;
 
@@ -17,17 +16,5 @@ class EditStand extends EditRecord
         return [
             DeleteAction::make(),
         ];
-    }
-
-    protected function mutateFormDataBeforeFill(array $data): array
-    {
-        $data['closed_at'] = $data['closed_at'] === null;
-        return $data;
-    }
-
-    public function mutateFormDataBeforeSave(array $data): array
-    {
-        $data['closed_at'] = $data['closed_at'] ? null : Carbon::now();
-        return $data;
     }
 }

--- a/app/Filament/Resources/Stands/Pages/ViewStand.php
+++ b/app/Filament/Resources/Stands/Pages/ViewStand.php
@@ -8,10 +8,4 @@ use Filament\Resources\Pages\ViewRecord;
 class ViewStand extends ViewRecord
 {
     protected static string $resource = StandResource::class;
-
-    protected function mutateFormDataBeforeFill(array $data): array
-    {
-        $data['closed_at'] = $data['closed_at'] === null;
-        return $data;
-    }
 }

--- a/app/Filament/Resources/Stands/StandResource.php
+++ b/app/Filament/Resources/Stands/StandResource.php
@@ -26,6 +26,7 @@ use App\Filament\Resources\StandResource\RelationManagers;
 use App\Models\Airfield\Airfield;
 use App\Models\Airfield\Terminal;
 use App\Models\Stand\Stand;
+use App\Models\Stand\StandAllocationStatus;
 use App\Models\Stand\StandType;
 use App\Rules\Airfield\PartialAirfieldIcao;
 use App\Rules\Stand\StandIdentifierMustBeUniqueAtAirfield;
@@ -161,9 +162,21 @@ class StandResource extends Resource
                             ->reactive()
                             ->numeric()
                             ->minValue(1),
-                        Toggle::make('closed_at')
-                            ->label(self::translateFormPath('used_for_allocation.label'))
-                            ->helperText(self::translateFormPath('used_for_allocation.helper'))
+                        Select::make('allocation_status')
+                            ->label(self::translateFormPath('allocation_status.label'))
+                            ->helperText(self::translateFormPath('allocation_status.helper'))
+                            ->options(
+                                collect(StandAllocationStatus::cases())
+                                    ->mapWithKeys(
+                                        fn (StandAllocationStatus $status) => [
+                                            $status->value => self::translateFormPath(
+                                                sprintf('allocation_status.options.%s', $status->value)
+                                            ),
+                                        ]
+                                    )
+                                    ->toArray()
+                            )
+                            ->default(StandAllocationStatus::Open->value)
                             ->required(),
                         TextInput::make('assignment_priority')
                             ->label(self::translateFormPath('allocation_priority.label'))
@@ -218,12 +231,14 @@ class StandResource extends Resource
                     ->badge()
                     ->wrap()
                     ->toggleable(isToggledHiddenByDefault: true),
-                IconColumn::make('closed_at')
-                    ->label(self::translateTablePath('columns.used'))
-                    ->getStateUsing(function (IconColumn $column) {
-                        return $column->getRecord()->closed_at === null;
-                    })
-                    ->boolean(),
+                TextColumn::make('allocation_status')
+                    ->label(self::translateTablePath('columns.allocation_status'))
+                    ->badge()
+                    ->formatStateUsing(
+                        fn (StandAllocationStatus $state): string => self::translateFormPath(
+                            sprintf('allocation_status.options.%s', $state->value)
+                        )
+                    ),
                 TextColumn::make('assignment_priority')
                     ->label(self::translateTablePath('columns.priority'))
                     ->sortable()

--- a/app/Http/Controllers/StandController.php
+++ b/app/Http/Controllers/StandController.php
@@ -56,7 +56,7 @@ class StandController extends BaseController
                     function (Airfield $airfield) {
                         return [
                             $airfield->code => $airfield->stands
-                                ->reject(fn (Stand $stand) => $stand->closed_at !== null)
+                                ->reject(fn (Stand $stand) => $stand->isUnavailable())
                                 ->values()
                                 ->map(fn (Stand $stand) => [
                                     'id' => $stand->id,

--- a/app/Http/Livewire/RequestAStandForm.php
+++ b/app/Http/Livewire/RequestAStandForm.php
@@ -67,7 +67,7 @@ class RequestAStandForm extends Component implements HasForms
         $this->stands = $userDestinationAirfield && $this->userAircraftType
             ? Stand::with('airfield')
                 ->where('airfield_id', $userDestinationAirfield->id)
-                ->notClosed()
+                ->open()
                 ->sizeAppropriate($this->userAircraftType)
                 ->get()
                 ->mapWithKeys(fn (Stand $stand): array => [$stand->id => $stand->airfieldIdentifier])

--- a/app/Http/Livewire/RequestAStandForm.php
+++ b/app/Http/Livewire/RequestAStandForm.php
@@ -67,7 +67,7 @@ class RequestAStandForm extends Component implements HasForms
         $this->stands = $userDestinationAirfield && $this->userAircraftType
             ? Stand::with('airfield')
                 ->where('airfield_id', $userDestinationAirfield->id)
-                ->open()
+                ->allocationOpen()
                 ->sizeAppropriate($this->userAircraftType)
                 ->get()
                 ->mapWithKeys(fn (Stand $stand): array => [$stand->id => $stand->airfieldIdentifier])

--- a/app/Models/Stand/Stand.php
+++ b/app/Models/Stand/Stand.php
@@ -135,10 +135,10 @@ class Stand extends Model
 
     public function scopeAvailableForArrival(Builder $builder): Builder
     {
-        return $this->scopeOpen($this->scopeNotReserved($this->scopeUnassigned($this->scopeUnoccupied($builder))));
+        return $this->scopeAllocationOpen($this->scopeNotReserved($this->scopeUnassigned($this->scopeUnoccupied($builder))));
     }
 
-    public function scopeOpen(Builder $query): Builder
+    public function scopeAllocationOpen(Builder $query): Builder
     {
         return $query->where('allocation_status', StandAllocationStatus::Open->value);
     }

--- a/app/Models/Stand/Stand.php
+++ b/app/Models/Stand/Stand.php
@@ -7,6 +7,7 @@ use App\Models\Airfield\Airfield;
 use App\Models\Airfield\Terminal;
 use App\Models\Airline\Airline;
 use App\Models\Vatsim\NetworkAircraft;
+use App\Models\Stand\StandAllocationStatus;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
@@ -37,6 +38,7 @@ class Stand extends Model
         'assignment_priority',
         'overnight_remote_preferred',
         'closed_at',
+        'allocation_status',
         'isOpen',
     ];
 
@@ -51,6 +53,7 @@ class Stand extends Model
         'created_at' => 'datetime',
         'updated_at' => 'datetime',
         'closed_at' => 'datetime',
+        'allocation_status' => StandAllocationStatus::class,
     ];
 
     public function assignment(): HasOne
@@ -127,7 +130,22 @@ class Stand extends Model
 
     public function scopeAvailable(Builder $builder): Builder
     {
-        return $this->scopeNotClosed($this->scopeNotReserved($this->scopeUnassigned($this->scopeUnoccupied($builder))));
+        return $this->scopeNotUnavailable($this->scopeNotReserved($this->scopeUnassigned($this->scopeUnoccupied($builder))));
+    }
+
+    public function scopeAvailableForArrival(Builder $builder): Builder
+    {
+        return $this->scopeOpen($this->scopeNotReserved($this->scopeUnassigned($this->scopeUnoccupied($builder))));
+    }
+
+    public function scopeOpen(Builder $query): Builder
+    {
+        return $query->where('allocation_status', StandAllocationStatus::Open->value);
+    }
+
+    public function scopeNotUnavailable(Builder $query): Builder
+    {
+        return $query->where('allocation_status', '!=', StandAllocationStatus::Unavailable->value);
     }
 
     public function scopeAirline(Builder $builder, Airline|int $airline): Builder
@@ -280,26 +298,43 @@ class Stand extends Model
         return $this->hasMany(StandReservation::class)->upcoming(Carbon::now()->addHour());
     }
 
-    public function isClosed(): bool
+    public function isOpen(): bool
     {
-        return $this->closed_at !== null;
+        return $this->allocation_status === StandAllocationStatus::Open;
     }
 
+    public function isClosedForArrivals(): bool
+    {
+        return $this->allocation_status === StandAllocationStatus::ClosedForArrivals;
+    }
+
+    public function isUnavailable(): bool
+    {
+        return $this->allocation_status === StandAllocationStatus::Unavailable;
+    }
+
+    public function closeForArrivals(): Stand
+    {
+        $this->update(['allocation_status' => StandAllocationStatus::ClosedForArrivals]);
+        return $this;
+    }
+
+    /**
+     * @deprecated Retained for historical data migrations. Use allocation_status instead.
+     */
     public function close(): Stand
     {
         $this->update(['closed_at' => Carbon::now()]);
         return $this;
     }
 
+    /**
+     * @deprecated Retained for historical data migrations. Use allocation_status instead.
+     */
     public function open(): Stand
     {
         $this->update(['closed_at' => null]);
         return $this;
-    }
-
-    public function scopeNotClosed(Builder $query): Builder
-    {
-        return $query->whereNull('closed_at');
     }
 
     public function getAirfieldIdentifierAttribute(): string

--- a/app/Models/Stand/StandAllocationStatus.php
+++ b/app/Models/Stand/StandAllocationStatus.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models\Stand;
+
+enum StandAllocationStatus: string
+{
+    case Open = 'open';
+    case ClosedForArrivals = 'closed_for_arrivals';
+    case Unavailable = 'unavailable';
+}

--- a/app/Services/Stand/DepartureAllocationService.php
+++ b/app/Services/Stand/DepartureAllocationService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services\Stand;
 
+use App\Models\Stand\StandAllocationStatus;
 use App\Models\Stand\StandAssignment;
 use App\Models\Vatsim\NetworkAircraft;
 use Illuminate\Database\Eloquent\Builder;
@@ -39,7 +40,7 @@ class DepartureAllocationService
     public function assignStandToDepartingAircraft(NetworkAircraft $aircraft): ?int
     {
         $occupiedStand = $this->standOccupationService->getOccupiedStand($aircraft);
-        if ($occupiedStand === null) {
+        if ($occupiedStand === null || $occupiedStand->isUnavailable()) {
             return null;
         }
 
@@ -66,6 +67,7 @@ class DepartureAllocationService
         return NetworkAircraft::join('aircraft_stand', 'network_aircraft.callsign', '=', 'aircraft_stand.callsign')
             ->join('stands', 'aircraft_stand.stand_id', '=', 'stands.id')
             ->join('airfield', 'airfield.id', '=', 'stands.airfield_id')
+            ->where('stands.allocation_status', '!=', StandAllocationStatus::Unavailable->value)
             ->leftJoin('stand_assignments', 'network_aircraft.callsign', '=', 'stand_assignments.callsign')
             ->where(function (Builder $subquery): void {
                 $subquery->whereRaw('aircraft_stand.stand_id <> stand_assignments.stand_id')

--- a/app/Services/Stand/StandAssignmentsService.php
+++ b/app/Services/Stand/StandAssignmentsService.php
@@ -48,6 +48,10 @@ class StandAssignmentsService
             throw new StandNotFoundException(sprintf('Stand with id %d not found', $standId));
         }
 
+        if ($stand->isUnavailable()) {
+            throw new StandNotFoundException(sprintf('Stand with id %d not found', $standId));
+        }
+
         [$assignment, $existingAssignments] = DB::transaction(function () use ($callsign, $stand, $assignmentType) {
             // Remove assignments for this and paired stands
             $existingAssignments = StandAssignment::with('stand')

--- a/app/Services/Stand/StandStatusService.php
+++ b/app/Services/Stand/StandStatusService.php
@@ -60,7 +60,7 @@ class StandStatusService
             ],
         ];
 
-        if ($stand->isClosed()) {
+        if ($stand->isUnavailable()) {
             $standData['status'] = 'closed';
         } elseif ($stand->occupier->first()) {
             $standData['status'] = 'occupied';

--- a/database/migrations/2026_08_02_000000_add_allocation_status_to_stands_table.php
+++ b/database/migrations/2026_08_02_000000_add_allocation_status_to_stands_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('stands', function (Blueprint $table) {
+            $table->string('allocation_status')->default('open')->index();
+        });
+
+        DB::table('stands')
+            ->whereNotNull('closed_at')
+            ->update(['allocation_status' => 'unavailable']);
+    }
+
+    public function down(): void
+    {
+        Schema::table('stands', function (Blueprint $table) {
+            $table->dropColumn('allocation_status');
+        });
+    }
+};

--- a/database/migrations/2026_08_02_000000_add_allocation_status_to_stands_table.php
+++ b/database/migrations/2026_08_02_000000_add_allocation_status_to_stands_table.php
@@ -5,8 +5,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class extends Migration {
     public function up(): void
     {
         Schema::table('stands', function (Blueprint $table) {

--- a/lang/en/stands/form.php
+++ b/lang/en/stands/form.php
@@ -39,10 +39,14 @@ return [
         'label' => 'Maximum Aircraft Wingspan',
         'helper' => 'Maximum aircraft size that can be assigned to the stand. Overrides maximum aerodrome reference code.',
     ],
-    'used_for_allocation' => [
-        'label' => 'Used for Allocation',
-        'helper' => 'Stands not used for allocation will not be allocated by the automatic allocator ' .
-            'or be available for controllers to assign.',
+    'allocation_status' => [
+        'label' => 'Allocation Status',
+        'helper' => 'Controls how the stand is used for allocation. Stands closed for arrivals will not be allocated to arriving aircraft but remain available for departure allocation and manual assignment. Unavailable stands are effectively draft stands and will not be allocated in any case.',
+        'options' => [
+            'open' => 'Used for allocation',
+            'closed_for_arrivals' => 'Closed for arrivals',
+            'unavailable' => 'Unavailable',
+        ],
     ],
     'allocation_priority' => [
         'label' => 'Allocation Priority',

--- a/lang/en/stands/table.php
+++ b/lang/en/stands/table.php
@@ -9,7 +9,7 @@ return [
         'max_size_wingspan' => 'Max Wingspan(m)',
         'max_size_length' => 'Max Length(m)',
         'airlines' => 'Airlines',
-        'used' => 'Used',
+        'allocation_status' => 'Allocation Status',
         'priority' => 'Allocation Priority',
         'overnight_remote_preferred' => 'Overnight Remote Preferred',
     ],

--- a/tests/app/Allocator/Stand/AirlineAircraftArrivalStandAllocatorTest.php
+++ b/tests/app/Allocator/Stand/AirlineAircraftArrivalStandAllocatorTest.php
@@ -7,6 +7,7 @@ use App\Models\Aircraft\Aircraft;
 use App\Models\Airfield\Airfield;
 use App\Models\Airline\Airline;
 use App\Models\Stand\Stand;
+use App\Models\Stand\StandAllocationStatus;
 use App\Models\Stand\StandRequest;
 use App\Models\Stand\StandReservation;
 use App\Models\Vatsim\NetworkAircraft;
@@ -440,7 +441,7 @@ class AirlineAircraftArrivalStandAllocatorTest extends BaseFunctionalTestCase
                 'airfield_id' => $airfieldId,
                 'identifier' => 'H1',
                 'aerodrome_reference_code' => 'C',
-                'closed_at' => Carbon::now(),
+                'allocation_status' => StandAllocationStatus::Unavailable,
             ]
         );
         $standH1->airlines()->sync([1 => ['aircraft_id' => 1]]);

--- a/tests/app/Allocator/Stand/AirlineAircraftTerminalArrivalStandAllocatorTest.php
+++ b/tests/app/Allocator/Stand/AirlineAircraftTerminalArrivalStandAllocatorTest.php
@@ -8,6 +8,7 @@ use App\Models\Airfield\Airfield;
 use App\Models\Airfield\Terminal;
 use App\Models\Airline\Airline;
 use App\Models\Stand\Stand;
+use App\Models\Stand\StandAllocationStatus;
 use App\Models\Stand\StandRequest;
 use App\Models\Stand\StandReservation;
 use App\Models\Vatsim\NetworkAircraft;
@@ -497,7 +498,7 @@ class AirlineAircraftTerminalArrivalStandAllocatorTest extends BaseFunctionalTes
             [
                 'airfield_id' => $airfieldId,
                 'identifier' => 'H1',
-                'closed_at' => Carbon::now()
+                'allocation_status' => StandAllocationStatus::Unavailable
             ]
         );
 

--- a/tests/app/Allocator/Stand/AirlineCallsignArrivalStandAllocatorTest.php
+++ b/tests/app/Allocator/Stand/AirlineCallsignArrivalStandAllocatorTest.php
@@ -7,6 +7,7 @@ use App\Models\Aircraft\Aircraft;
 use App\Models\Airfield\Airfield;
 use App\Models\Airline\Airline;
 use App\Models\Stand\Stand;
+use App\Models\Stand\StandAllocationStatus;
 use App\Models\Stand\StandRequest;
 use App\Models\Stand\StandReservation;
 use App\Models\Vatsim\NetworkAircraft;
@@ -469,7 +470,7 @@ class AirlineCallsignArrivalStandAllocatorTest extends BaseFunctionalTestCase
                 'airfield_id' => $airfieldId,
                 'identifier' => 'H1',
                 'aerodrome_reference_code' => 'C',
-                'closed_at' => Carbon::now(),
+                'allocation_status' => StandAllocationStatus::Unavailable,
             ]
         );
         $standH1->airlines()->sync([1 => ['full_callsign' => '23451']]);

--- a/tests/app/Allocator/Stand/AirlineCallsignSlugArrivalStandAllocatorTest.php
+++ b/tests/app/Allocator/Stand/AirlineCallsignSlugArrivalStandAllocatorTest.php
@@ -7,6 +7,7 @@ use App\Models\Aircraft\Aircraft;
 use App\Models\Airfield\Airfield;
 use App\Models\Airline\Airline;
 use App\Models\Stand\Stand;
+use App\Models\Stand\StandAllocationStatus;
 use App\Models\Stand\StandRequest;
 use App\Models\Stand\StandReservation;
 use App\Models\Vatsim\NetworkAircraft;
@@ -613,7 +614,7 @@ class AirlineCallsignSlugArrivalStandAllocatorTest extends BaseFunctionalTestCas
                 'airfield_id' => $airfieldId,
                 'identifier' => 'H1',
                 'aerodrome_reference_code' => 'C',
-                'closed_at' => Carbon::now(),
+                'allocation_status' => StandAllocationStatus::Unavailable,
             ]
         );
         $standH1->airlines()->sync([1 => ['callsign_slug' => '23451']]);

--- a/tests/app/Allocator/Stand/AirlineCallsignSlugTerminalArrivalStandAllocatorTest.php
+++ b/tests/app/Allocator/Stand/AirlineCallsignSlugTerminalArrivalStandAllocatorTest.php
@@ -8,6 +8,7 @@ use App\Models\Airfield\Airfield;
 use App\Models\Airfield\Terminal;
 use App\Models\Airline\Airline;
 use App\Models\Stand\Stand;
+use App\Models\Stand\StandAllocationStatus;
 use App\Models\Stand\StandRequest;
 use App\Models\Stand\StandReservation;
 use App\Models\Vatsim\NetworkAircraft;
@@ -709,7 +710,7 @@ class AirlineCallsignSlugTerminalArrivalStandAllocatorTest extends BaseFunctiona
             [
                 'airfield_id' => $airfieldId,
                 'identifier' => 'H1',
-                'closed_at' => Carbon::now()
+                'allocation_status' => StandAllocationStatus::Unavailable
             ]
         );
 

--- a/tests/app/Allocator/Stand/AirlineCallsignTerminalArrivalStandAllocatorTest.php
+++ b/tests/app/Allocator/Stand/AirlineCallsignTerminalArrivalStandAllocatorTest.php
@@ -8,6 +8,7 @@ use App\Models\Airfield\Airfield;
 use App\Models\Airfield\Terminal;
 use App\Models\Airline\Airline;
 use App\Models\Stand\Stand;
+use App\Models\Stand\StandAllocationStatus;
 use App\Models\Stand\StandRequest;
 use App\Models\Stand\StandReservation;
 use App\Models\Vatsim\NetworkAircraft;
@@ -521,7 +522,7 @@ class AirlineCallsignTerminalArrivalStandAllocatorTest extends BaseFunctionalTes
             [
                 'airfield_id' => $airfieldId,
                 'identifier' => 'H1',
-                'closed_at' => Carbon::now()
+                'allocation_status' => StandAllocationStatus::Unavailable
             ]
         );
 

--- a/tests/app/Allocator/Stand/AirlineDestinationArrivalStandAllocatorTest.php
+++ b/tests/app/Allocator/Stand/AirlineDestinationArrivalStandAllocatorTest.php
@@ -7,6 +7,7 @@ use App\Models\Aircraft\Aircraft;
 use App\Models\Airfield\Airfield;
 use App\Models\Airline\Airline;
 use App\Models\Stand\Stand;
+use App\Models\Stand\StandAllocationStatus;
 use App\Models\Stand\StandRequest;
 use App\Models\Stand\StandReservation;
 use App\Models\Vatsim\NetworkAircraft;
@@ -611,7 +612,7 @@ class AirlineDestinationArrivalStandAllocatorTest extends BaseFunctionalTestCase
                 'airfield_id' => $airfieldId,
                 'identifier' => 'H1',
                 'aerodrome_reference_code' => 'C',
-                'closed_at' => Carbon::now(),
+                'allocation_status' => StandAllocationStatus::Unavailable,
             ]
         );
         $standH1->airlines()->sync([1 => ['destination' => 'EGGD']]);

--- a/tests/app/Allocator/Stand/AirlineDestinationTerminalArrivalStandAllocatorTest.php
+++ b/tests/app/Allocator/Stand/AirlineDestinationTerminalArrivalStandAllocatorTest.php
@@ -8,6 +8,7 @@ use App\Models\Airfield\Airfield;
 use App\Models\Airfield\Terminal;
 use App\Models\Airline\Airline;
 use App\Models\Stand\Stand;
+use App\Models\Stand\StandAllocationStatus;
 use App\Models\Stand\StandRequest;
 use App\Models\Stand\StandReservation;
 use App\Models\Vatsim\NetworkAircraft;
@@ -700,7 +701,7 @@ class AirlineDestinationTerminalArrivalStandAllocatorTest extends BaseFunctional
             [
                 'airfield_id' => $airfieldId,
                 'identifier' => 'H1',
-                'closed_at' => Carbon::now()
+                'allocation_status' => StandAllocationStatus::Unavailable
             ]
         );
 

--- a/tests/app/Allocator/Stand/AirlineGeneralArrivalStandAllocatorTest.php
+++ b/tests/app/Allocator/Stand/AirlineGeneralArrivalStandAllocatorTest.php
@@ -7,6 +7,7 @@ use App\Models\Aircraft\Aircraft;
 use App\Models\Airfield\Airfield;
 use App\Models\Airline\Airline;
 use App\Models\Stand\Stand;
+use App\Models\Stand\StandAllocationStatus;
 use App\Models\Stand\StandRequest;
 use App\Models\Stand\StandReservation;
 use App\Models\Vatsim\NetworkAircraft;
@@ -455,7 +456,7 @@ class AirlineGeneralArrivalStandAllocatorTest extends BaseFunctionalTestCase
                 'airfield_id' => $airfieldId,
                 'identifier' => 'H1',
                 'aerodrome_reference_code' => 'C',
-                'closed_at' => Carbon::now(),
+                'allocation_status' => StandAllocationStatus::Unavailable,
             ]
         );
         $standH1->airlines()->sync([1]);

--- a/tests/app/Allocator/Stand/AirlineGeneralTerminalArrivalStandAllocatorTest.php
+++ b/tests/app/Allocator/Stand/AirlineGeneralTerminalArrivalStandAllocatorTest.php
@@ -8,6 +8,7 @@ use App\Models\Airfield\Airfield;
 use App\Models\Airfield\Terminal;
 use App\Models\Airline\Airline;
 use App\Models\Stand\Stand;
+use App\Models\Stand\StandAllocationStatus;
 use App\Models\Stand\StandRequest;
 use App\Models\Stand\StandReservation;
 use App\Models\Vatsim\NetworkAircraft;
@@ -399,7 +400,7 @@ class AirlineGeneralTerminalArrivalStandAllocatorTest extends BaseFunctionalTest
             [
                 'airfield_id' => $airfieldId,
                 'identifier' => 'H1',
-                'closed_at' => Carbon::now()
+                'allocation_status' => StandAllocationStatus::Unavailable
             ]
         );
 

--- a/tests/app/Allocator/Stand/CargoAirlineFallbackStandAllocatorTest.php
+++ b/tests/app/Allocator/Stand/CargoAirlineFallbackStandAllocatorTest.php
@@ -7,6 +7,7 @@ use App\Models\Aircraft\Aircraft;
 use App\Models\Airfield\Airfield;
 use App\Models\Airline\Airline;
 use App\Models\Stand\Stand;
+use App\Models\Stand\StandAllocationStatus;
 use App\Models\Stand\StandAssignment;
 use App\Models\Stand\StandRequest;
 use App\Models\Stand\StandReservation;
@@ -240,7 +241,7 @@ class CargoAirlineFallbackStandAllocatorTest extends BaseFunctionalTestCase
                 'airfield_id' => $airfieldId,
                 'identifier' => 'H1',
                 'aerodrome_reference_code' => 'E',
-                'closed_at' => Carbon::now(),
+                'allocation_status' => StandAllocationStatus::Unavailable,
                 'type_id' => 3,
             ]
         );

--- a/tests/app/Allocator/Stand/CargoFlightArrivalStandAllocatorTest.php
+++ b/tests/app/Allocator/Stand/CargoFlightArrivalStandAllocatorTest.php
@@ -7,6 +7,7 @@ use App\Models\Aircraft\Aircraft;
 use App\Models\Airfield\Airfield;
 use App\Models\Airline\Airline;
 use App\Models\Stand\Stand;
+use App\Models\Stand\StandAllocationStatus;
 use App\Models\Stand\StandAssignment;
 use App\Models\Stand\StandRequest;
 use App\Models\Stand\StandReservation;
@@ -236,7 +237,7 @@ class CargoFlightArrivalStandAllocatorTest extends BaseFunctionalTestCase
                 'airfield_id' => $airfieldId,
                 'identifier' => 'H1',
                 'aerodrome_reference_code' => 'E',
-                'closed_at' => Carbon::now(),
+                'allocation_status' => StandAllocationStatus::Unavailable,
                 'type_id' => 3,
             ]
         );

--- a/tests/app/Allocator/Stand/CargoFlightPreferredArrivalStandAllocatorTest.php
+++ b/tests/app/Allocator/Stand/CargoFlightPreferredArrivalStandAllocatorTest.php
@@ -7,6 +7,7 @@ use App\Models\Aircraft\Aircraft;
 use App\Models\Airfield\Airfield;
 use App\Models\Airline\Airline;
 use App\Models\Stand\Stand;
+use App\Models\Stand\StandAllocationStatus;
 use App\Models\Stand\StandAssignment;
 use App\Models\Stand\StandRequest;
 use App\Models\Stand\StandReservation;
@@ -271,7 +272,7 @@ class CargoFlightPreferredArrivalStandAllocatorTest extends BaseFunctionalTestCa
                 'airfield_id' => $airfieldId,
                 'identifier' => 'H1',
                 'aerodrome_reference_code' => 'E',
-                'closed_at' => Carbon::now(),
+                'allocation_status' => StandAllocationStatus::Unavailable,
                 'type_id' => 3,
             ]
         );

--- a/tests/app/Allocator/Stand/DomesticInternationalStandAllocatorTest.php
+++ b/tests/app/Allocator/Stand/DomesticInternationalStandAllocatorTest.php
@@ -6,6 +6,7 @@ use App\BaseFunctionalTestCase;
 use App\Models\Aircraft\Aircraft;
 use App\Models\Airfield\Airfield;
 use App\Models\Stand\Stand;
+use App\Models\Stand\StandAllocationStatus;
 use App\Models\Stand\StandAssignment;
 use App\Models\Stand\StandRequest;
 use App\Models\Stand\StandReservation;
@@ -297,7 +298,7 @@ class DomesticInternationalStandAllocatorTest extends BaseFunctionalTestCase
                 'airfield_id' => $airfieldId,
                 'identifier' => 'H1',
                 'aerodrome_reference_code' => 'E',
-                'closed_at' => Carbon::now(),
+                'allocation_status' => StandAllocationStatus::Unavailable,
                 'type_id' => 1,
             ]
         );
@@ -431,7 +432,7 @@ class DomesticInternationalStandAllocatorTest extends BaseFunctionalTestCase
                 'airfield_id' => $airfieldId,
                 'identifier' => 'H1',
                 'aerodrome_reference_code' => 'E',
-                'closed_at' => Carbon::now(),
+                'allocation_status' => StandAllocationStatus::Unavailable,
                 'type_id' => 1,
             ]
         );

--- a/tests/app/Allocator/Stand/FallbackArrivalStandAllocatorTest.php
+++ b/tests/app/Allocator/Stand/FallbackArrivalStandAllocatorTest.php
@@ -6,6 +6,7 @@ use App\BaseFunctionalTestCase;
 use App\Models\Aircraft\Aircraft;
 use App\Models\Airfield\Airfield;
 use App\Models\Stand\Stand;
+use App\Models\Stand\StandAllocationStatus;
 use App\Models\Stand\StandRequest;
 use App\Models\Stand\StandReservation;
 use App\Models\Stand\StandType;
@@ -447,7 +448,7 @@ class FallbackArrivalStandAllocatorTest extends BaseFunctionalTestCase
                 'airfield_id' => $airfieldId,
                 'identifier' => 'H1',
                 'aerodrome_reference_code' => 'E',
-                'closed_at' => Carbon::now()
+                'allocation_status' => StandAllocationStatus::Unavailable
             ]
         );
 
@@ -467,6 +468,24 @@ class FallbackArrivalStandAllocatorTest extends BaseFunctionalTestCase
             ->toArray();
 
         $this->assertEquals($expectedRanks, $actualRanks);
+    }
+
+    public function testItDoesntRankClosedForArrivalsStands()
+    {
+        $airfield = Airfield::factory()->create(['code' => 'EXXX']);
+        $stand = Stand::factory()->create(
+            [
+                'airfield_id' => $airfield->id,
+                'identifier' => 'A1',
+                'allocation_status' => StandAllocationStatus::ClosedForArrivals,
+            ]
+        );
+
+        $ranks = $this->allocator->getRankedStandAllocation(
+            $this->newAircraft('VIR22F', 'B738', $airfield->code)
+        )->pluck('id')->toArray();
+
+        $this->assertNotContains($stand->id, $ranks);
     }
 
     private function createAircraft(

--- a/tests/app/Allocator/Stand/OriginAirfieldStandAllocatorTest.php
+++ b/tests/app/Allocator/Stand/OriginAirfieldStandAllocatorTest.php
@@ -6,6 +6,7 @@ use App\BaseFunctionalTestCase;
 use App\Models\Aircraft\Aircraft;
 use App\Models\Airfield\Airfield;
 use App\Models\Stand\Stand;
+use App\Models\Stand\StandAllocationStatus;
 use App\Models\Stand\StandRequest;
 use App\Models\Stand\StandReservation;
 use App\Models\Vatsim\NetworkAircraft;
@@ -397,7 +398,7 @@ class OriginAirfieldStandAllocatorTest extends BaseFunctionalTestCase
                 'airfield_id' => $airfieldId,
                 'identifier' => 'H1',
                 'aerodrome_reference_code' => 'C',
-                'closed_at' => Carbon::now(),
+                'allocation_status' => StandAllocationStatus::Unavailable,
                 'origin_slug' => 'EGGD',
             ]
         );

--- a/tests/app/Filament/Helpers/SelectOptionsTest.php
+++ b/tests/app/Filament/Helpers/SelectOptionsTest.php
@@ -12,7 +12,7 @@ use App\Models\Controller\Handoff;
 use App\Models\IntentionCode\FirExitPoint;
 use App\Models\Runway\Runway;
 use App\Models\Stand\Stand;
-use Carbon\Carbon;
+use App\Models\Stand\StandAllocationStatus;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 
@@ -844,8 +844,8 @@ class SelectOptionsTest extends BaseFunctionalTestCase
 
     public function testItGetsAndCachesStands()
     {
-        // Stand is closed, shouldn't show
-        Stand::factory()->create(['airfield_id' => 1, 'closed_at' => Carbon::now()]);
+        // Stand is unavailable, shouldn't show
+        Stand::factory()->create(['airfield_id' => 1, 'allocation_status' => StandAllocationStatus::Unavailable]);
         $expected = collect([
             1 => 'EGLL / 1L',
             2 => 'EGLL / 251',
@@ -853,6 +853,20 @@ class SelectOptionsTest extends BaseFunctionalTestCase
 
         $this->assertEquals($expected, SelectOptions::standsForAirfield(Airfield::find(1)));
         $this->assertEquals($expected, Cache::get('SELECT_OPTIONS_STANDS_EGLL'));
+    }
+
+    public function testItIncludesClosedForArrivalsStandsForAirfield()
+    {
+        $stand = Stand::factory()->create(
+            [
+                'airfield_id' => 1,
+                'allocation_status' => StandAllocationStatus::ClosedForArrivals,
+            ]
+        );
+
+        $this->assertTrue(
+            SelectOptions::standsForAirfield(Airfield::findOrFail(1))->has($stand->id)
+        );
     }
 
     public function testItGetsCachedStandsWithoutQuerying()

--- a/tests/app/Filament/StandResourceTest.php
+++ b/tests/app/Filament/StandResourceTest.php
@@ -12,6 +12,7 @@ use App\Filament\Resources\Stands\RelationManagers\PairedStandsRelationManager;
 use App\Models\Airfield\Terminal;
 use App\Models\Airline\Airline;
 use App\Models\Stand\Stand;
+use App\Models\Stand\StandAllocationStatus;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
@@ -74,7 +75,7 @@ class StandResourceTest extends BaseFilamentTestCase
             ->assertSet('data.assignment_priority', 100)
             ->assertSet('data.max_aircraft_wingspan', 1)
             ->assertSet('data.max_aircraft_length', 2)
-            ->assertSet('data.closed_at', true);
+            ->assertSet('data.allocation_status', StandAllocationStatus::Open->value);
     }
 
     public function testItRetrievesDataForViewOfClosedStands()
@@ -89,7 +90,7 @@ class StandResourceTest extends BaseFilamentTestCase
                     'max_aircraft_length' => 2,
                 ]
             );
-        Stand::findOrFail(1)->close();
+        Stand::findOrFail(1)->update(['allocation_status' => StandAllocationStatus::Unavailable]);
 
         Livewire::test(ViewStand::class, ['record' => 1])
             ->assertSet('data.airfield_id', 1)
@@ -103,7 +104,7 @@ class StandResourceTest extends BaseFilamentTestCase
             ->assertSet('data.assignment_priority', 100)
             ->assertSet('data.max_aircraft_wingspan', 1)
             ->assertSet('data.max_aircraft_length', 2)
-            ->assertSet('data.closed_at', false);
+            ->assertSet('data.allocation_status', StandAllocationStatus::Unavailable->value);
     }
 
     public function testItCreatesAStandWithMinimalData()
@@ -131,7 +132,7 @@ class StandResourceTest extends BaseFilamentTestCase
                 'max_aircraft_wingspan' => null,
                 'max_aircraft_length' => null,
                 'assignment_priority' => 100,
-                'closed_at' => Carbon::now(),
+                'allocation_status' => StandAllocationStatus::Open->value,
             ]
         );
     }
@@ -162,7 +163,7 @@ class StandResourceTest extends BaseFilamentTestCase
                 'max_aircraft_wingspan' => null,
                 'max_aircraft_length' => null,
                 'assignment_priority' => 100,
-                'closed_at' => Carbon::now(),
+                'allocation_status' => StandAllocationStatus::Open->value,
             ]
         );
     }
@@ -181,7 +182,7 @@ class StandResourceTest extends BaseFilamentTestCase
             ->set('data.max_aircraft_wingspan', 1)
             ->set('data.max_aircraft_length', 2)
             ->set('data.assigment_priority', 99)
-            ->set('data.closed_at', true)
+            ->set('data.allocation_status', StandAllocationStatus::Open->value)
             ->call('create')
             ->assertHasNoErrors();
 
@@ -199,7 +200,28 @@ class StandResourceTest extends BaseFilamentTestCase
                 'max_aircraft_wingspan' => 1,
                 'max_aircraft_length' => 2,
                 'assignment_priority' => 100,
-                'closed_at' => null,
+                'allocation_status' => StandAllocationStatus::Open->value,
+            ]
+        );
+    }
+
+    public function testItCreatesAStandClosedForArrivals()
+    {
+        Livewire::test(CreateStand::class)
+            ->set('data.airfield_id', 1)
+            ->set('data.identifier', '33L')
+            ->set('data.latitude', 4.5)
+            ->set('data.longitude', 5.6)
+            ->set('data.aerodrome_reference_code', 'D')
+            ->set('data.allocation_status', StandAllocationStatus::ClosedForArrivals->value)
+            ->call('create')
+            ->assertHasNoErrors();
+
+        $this->assertDatabaseHas(
+            'stands',
+            [
+                'identifier' => '33L',
+                'allocation_status' => StandAllocationStatus::ClosedForArrivals->value,
             ]
         );
     }
@@ -214,7 +236,7 @@ class StandResourceTest extends BaseFilamentTestCase
             ->set('data.type_id', 3)
             ->set('data.aerodrome_reference_code', 'D')
             ->set('data.assigment_priority', 99)
-            ->set('data.closed_at', true)
+            ->set('data.allocation_status', StandAllocationStatus::Open->value)
             ->call('create')
             ->assertHasErrors(['data.airfield_id' => 'required']);
     }
@@ -229,7 +251,7 @@ class StandResourceTest extends BaseFilamentTestCase
             ->set('data.type_id', 3)
             ->set('data.aerodrome_reference_code', 'D')
             ->set('data.assigment_priority', 99)
-            ->set('data.closed_at', true)
+            ->set('data.allocation_status', StandAllocationStatus::Open->value)
             ->call('create')
             ->assertHasErrors(['data.identifier' => 'required']);
     }
@@ -245,7 +267,7 @@ class StandResourceTest extends BaseFilamentTestCase
             ->set('data.type_id', 3)
             ->set('data.aerodrome_reference_code', 'D')
             ->set('data.assigment_priority', 99)
-            ->set('data.closed_at', true)
+            ->set('data.allocation_status', StandAllocationStatus::Open->value)
             ->call('create')
             ->assertHasErrors(['data.identifier' => 'required']);
     }
@@ -261,7 +283,7 @@ class StandResourceTest extends BaseFilamentTestCase
             ->set('data.type_id', 3)
             ->set('data.aerodrome_reference_code', 'D')
             ->set('data.assigment_priority', 99)
-            ->set('data.closed_at', true)
+            ->set('data.allocation_status', StandAllocationStatus::Open->value)
             ->call('create')
             ->assertHasErrors(['data.identifier']);
     }
@@ -277,7 +299,7 @@ class StandResourceTest extends BaseFilamentTestCase
             ->set('data.type_id', 3)
             ->set('data.aerodrome_reference_code', 'D')
             ->set('data.assigment_priority', 99)
-            ->set('data.closed_at', true)
+            ->set('data.allocation_status', StandAllocationStatus::Open->value)
             ->call('create')
             ->assertHasErrors(['data.latitude']);
     }
@@ -293,7 +315,7 @@ class StandResourceTest extends BaseFilamentTestCase
             ->set('data.type_id', 3)
             ->set('data.aerodrome_reference_code', 'D')
             ->set('data.assigment_priority', 99)
-            ->set('data.closed_at', true)
+            ->set('data.allocation_status', StandAllocationStatus::Open->value)
             ->call('create')
             ->assertHasErrors(['data.longitude']);
     }
@@ -309,7 +331,7 @@ class StandResourceTest extends BaseFilamentTestCase
             ->set('data.type_id', 3)
             ->set('data.aerodrome_reference_code', 'D')
             ->set('data.assignment_priority', 'abc')
-            ->set('data.closed_at', true)
+            ->set('data.allocation_status', StandAllocationStatus::Open->value)
             ->call('create')
             ->assertHasErrors(['data.assignment_priority']);
     }
@@ -325,7 +347,7 @@ class StandResourceTest extends BaseFilamentTestCase
             ->set('data.type_id', 3)
             ->set('data.aerodrome_reference_code', 'D')
             ->set('data.assignment_priority', 0)
-            ->set('data.closed_at', true)
+            ->set('data.allocation_status', StandAllocationStatus::Open->value)
             ->call('create')
             ->assertHasErrors(['data.assignment_priority']);
     }
@@ -341,7 +363,7 @@ class StandResourceTest extends BaseFilamentTestCase
             ->set('data.type_id', 3)
             ->set('data.aerodrome_reference_code', 'D')
             ->set('data.assignment_priority', 99999)
-            ->set('data.closed_at', true)
+            ->set('data.allocation_status', StandAllocationStatus::Open->value)
             ->call('create')
             ->assertHasErrors(['data.assignment_priority']);
     }
@@ -358,7 +380,7 @@ class StandResourceTest extends BaseFilamentTestCase
             ->set('data.origin_slug', 'EGLLLL')
             ->set('data.aerodrome_reference_code', 'D')
             ->set('data.assignment_priority', 100)
-            ->set('data.closed_at', true)
+            ->set('data.allocation_status', StandAllocationStatus::Open->value)
             ->call('create')
             ->assertHasErrors(['data.origin_slug']);
     }
@@ -377,7 +399,7 @@ class StandResourceTest extends BaseFilamentTestCase
             ->set('data.assignment_priority', 100)
             ->set('data.max_aircraft_wingspan', "abc")
             ->set('data.max_aircraft_length', 1)
-            ->set('data.closed_at', true)
+            ->set('data.allocation_status', StandAllocationStatus::Open->value)
             ->call('create')
             ->assertHasErrors(['data.max_aircraft_wingspan']);
     }
@@ -396,7 +418,7 @@ class StandResourceTest extends BaseFilamentTestCase
             ->set('data.assignment_priority', 100)
             ->set('data.max_aircraft_wingspan', 1)
             ->set('data.max_aircraft_length', "abc")
-            ->set('data.closed_at', true)
+            ->set('data.allocation_status', StandAllocationStatus::Open->value)
             ->call('create')
             ->assertHasErrors(['data.max_aircraft_length']);
     }
@@ -426,7 +448,7 @@ class StandResourceTest extends BaseFilamentTestCase
             ->assertSet('data.assignment_priority', 100)
             ->assertSet('data.max_aircraft_wingspan', 1)
             ->assertSet('data.max_aircraft_length', 2)
-            ->assertSet('data.closed_at', true);
+            ->assertSet('data.allocation_status', StandAllocationStatus::Open->value);
     }
 
     public function testItRetrievesDataForEditOfClosedStands()
@@ -442,7 +464,7 @@ class StandResourceTest extends BaseFilamentTestCase
                     'origin_slug' => 'EGGD',
                 ]
             );
-        Stand::findOrFail(1)->close();
+        Stand::findOrFail(1)->update(['allocation_status' => StandAllocationStatus::Unavailable]);
 
         Livewire::test(EditStand::class, ['record' => 1])
             ->assertSet('data.airfield_id', 1)
@@ -456,7 +478,7 @@ class StandResourceTest extends BaseFilamentTestCase
             ->assertSet('data.assignment_priority', 100)
             ->assertSet('data.max_aircraft_wingspan', 1)
             ->assertSet('data.max_aircraft_length', 2)
-            ->assertSet('data.closed_at', false);
+            ->assertSet('data.allocation_status', StandAllocationStatus::Unavailable->value);
     }
 
     public function testItEditsAStandWithMinimalData()
@@ -485,7 +507,7 @@ class StandResourceTest extends BaseFilamentTestCase
                 'max_aircraft_wingspan' => null,
                 'max_aircraft_length' => null,
                 'assignment_priority' => 100,
-                'closed_at' => null,
+                'allocation_status' => StandAllocationStatus::Open->value,
             ]
         );
     }
@@ -516,7 +538,7 @@ class StandResourceTest extends BaseFilamentTestCase
                 'max_aircraft_wingspan' => null,
                 'max_aircraft_length' => null,
                 'assignment_priority' => 100,
-                'closed_at' => null,
+                'allocation_status' => StandAllocationStatus::Open->value,
             ]
         );
     }
@@ -553,7 +575,7 @@ class StandResourceTest extends BaseFilamentTestCase
                 'max_aircraft_wingspan' => 1,
                 'max_aircraft_length' => 2,
                 'assignment_priority' => 100,
-                'closed_at' => null,
+                'allocation_status' => StandAllocationStatus::Open->value,
             ]
         );
     }
@@ -569,7 +591,7 @@ class StandResourceTest extends BaseFilamentTestCase
             ->set('data.type_id', 3)
             ->set('data.aerodrome_reference_code', 'D')
             ->set('data.assigment_priority', 99)
-            ->set('data.closed_at', true)
+            ->set('data.allocation_status', StandAllocationStatus::Open->value)
             ->call('save')
             ->assertHasErrors(['data.identifier' => 'required']);
     }
@@ -585,7 +607,7 @@ class StandResourceTest extends BaseFilamentTestCase
             ->set('data.type_id', 3)
             ->set('data.aerodrome_reference_code', 'D')
             ->set('data.assigment_priority', 99)
-            ->set('data.closed_at', true)
+            ->set('data.allocation_status', StandAllocationStatus::Open->value)
             ->call('save')
             ->assertHasErrors(['data.identifier']);
     }
@@ -601,7 +623,7 @@ class StandResourceTest extends BaseFilamentTestCase
             ->set('data.type_id', 3)
             ->set('data.aerodrome_reference_code', 'D')
             ->set('data.assigment_priority', 99)
-            ->set('data.closed_at', true)
+            ->set('data.allocation_status', StandAllocationStatus::Open->value)
             ->call('save')
             ->assertHasErrors(['data.latitude']);
     }
@@ -617,7 +639,7 @@ class StandResourceTest extends BaseFilamentTestCase
             ->set('data.type_id', 3)
             ->set('data.aerodrome_reference_code', 'D')
             ->set('data.assigment_priority', 99)
-            ->set('data.closed_at', true)
+            ->set('data.allocation_status', StandAllocationStatus::Open->value)
             ->call('save')
             ->assertHasErrors(['data.longitude']);
     }
@@ -633,7 +655,7 @@ class StandResourceTest extends BaseFilamentTestCase
             ->set('data.type_id', 3)
             ->set('data.aerodrome_reference_code', 'D')
             ->set('data.assignment_priority', 'abc')
-            ->set('data.closed_at', true)
+            ->set('data.allocation_status', StandAllocationStatus::Open->value)
             ->call('save')
             ->assertHasErrors(['data.assignment_priority']);
     }
@@ -649,7 +671,7 @@ class StandResourceTest extends BaseFilamentTestCase
             ->set('data.type_id', 3)
             ->set('data.aerodrome_reference_code', 'D')
             ->set('data.assignment_priority', 0)
-            ->set('data.closed_at', true)
+            ->set('data.allocation_status', StandAllocationStatus::Open->value)
             ->call('save')
             ->assertHasErrors(['data.assignment_priority']);
     }
@@ -665,7 +687,7 @@ class StandResourceTest extends BaseFilamentTestCase
             ->set('data.type_id', 3)
             ->set('data.aerodrome_reference_code', 'D')
             ->set('data.assignment_priority', 99999)
-            ->set('data.closed_at', true)
+            ->set('data.allocation_status', StandAllocationStatus::Open->value)
             ->call('save')
             ->assertHasErrors(['data.assignment_priority']);
     }
@@ -682,7 +704,7 @@ class StandResourceTest extends BaseFilamentTestCase
             ->set('data.origin_slug', 'EGGGG')
             ->set('data.aerodrome_reference_code', 'D')
             ->set('data.assignment_priority', 100)
-            ->set('data.closed_at', true)
+            ->set('data.allocation_status', StandAllocationStatus::Open->value)
             ->call('save')
             ->assertHasErrors(['data.origin_slug']);
     }
@@ -701,7 +723,7 @@ class StandResourceTest extends BaseFilamentTestCase
             ->set('data.assignment_priority', 100)
             ->set('data.max_aircraft_length', "abc")
             ->set('data.max_aircraft_wingspan', 1)
-            ->set('data.closed_at', true)
+            ->set('data.allocation_status', StandAllocationStatus::Open->value)
             ->call('save')
             ->assertHasErrors(['data.max_aircraft_length']);
     }
@@ -720,7 +742,7 @@ class StandResourceTest extends BaseFilamentTestCase
             ->set('data.assignment_priority', 100)
             ->set('data.max_aircraft_length', 1)
             ->set('data.max_aircraft_wingspan', "abc")
-            ->set('data.closed_at', true)
+            ->set('data.allocation_status', StandAllocationStatus::Open->value)
             ->call('save')
             ->assertHasErrors(['data.max_aircraft_wingspan']);
     }
@@ -739,7 +761,7 @@ class StandResourceTest extends BaseFilamentTestCase
             ->set('data.assignment_priority', 100)
             ->set('data.max_aircraft_length', -1)
             ->set('data.max_aircraft_wingspan', 1)
-            ->set('data.closed_at', true)
+            ->set('data.allocation_status', StandAllocationStatus::Open->value)
             ->call('save')
             ->assertHasErrors(['data.max_aircraft_length']);
     }
@@ -758,7 +780,7 @@ class StandResourceTest extends BaseFilamentTestCase
             ->set('data.assignment_priority', 100)
             ->set('data.max_aircraft_length', 1)
             ->set('data.max_aircraft_wingspan', -1)
-            ->set('data.closed_at', true)
+            ->set('data.allocation_status', StandAllocationStatus::Open->value)
             ->call('save')
             ->assertHasErrors(['data.max_aircraft_wingspan']);
     }

--- a/tests/app/Http/Controllers/StandControllerTest.php
+++ b/tests/app/Http/Controllers/StandControllerTest.php
@@ -6,6 +6,7 @@ use App\BaseApiTestCase;
 use App\Events\StandAssignedEvent;
 use App\Events\StandUnassignedEvent;
 use App\Models\Stand\Stand;
+use App\Models\Stand\StandAllocationStatus;
 use App\Models\Stand\StandAssignment;
 use App\Services\NetworkAircraftService;
 use Carbon\Carbon;
@@ -47,15 +48,46 @@ class StandControllerTest extends BaseApiTestCase
             ->assertStatus(200);
     }
 
-    public function testStandDependencyIgnoresClosedStands()
+    public function testStandDependencyIgnoresUnavailableStands()
     {
         Stand::where('identifier', '1L')
             ->airfield('EGLL')
             ->firstOrFail()
-            ->close();
+            ->update(['allocation_status' => StandAllocationStatus::Unavailable]);
 
         $expected = [
             'EGLL' => [
+                [
+                    'id' => 2,
+                    'identifier' => '251',
+                ],
+            ],
+            'EGBB' => [
+                [
+                    'id' => 3,
+                    'identifier' => '32',
+                ]
+            ],
+        ];
+
+        $this->makeUnauthenticatedApiRequest(self::METHOD_GET, 'stand/dependency')
+            ->assertJson($expected)
+            ->assertStatus(200);
+    }
+
+    public function testStandDependencyIncludesClosedForArrivalsStands()
+    {
+        Stand::where('identifier', '1L')
+            ->airfield('EGLL')
+            ->firstOrFail()
+            ->update(['allocation_status' => StandAllocationStatus::ClosedForArrivals]);
+
+        $expected = [
+            'EGLL' => [
+                [
+                    'id' => 1,
+                    'identifier' => '1L',
+                ],
                 [
                     'id' => 2,
                     'identifier' => '251',

--- a/tests/app/Http/Livewire/DepartureStandFinderFormTest.php
+++ b/tests/app/Http/Livewire/DepartureStandFinderFormTest.php
@@ -7,6 +7,7 @@ use App\Models\Aircraft\Aircraft;
 use App\Models\Airfield\Airfield;
 use App\Models\Airline\Airline;
 use App\Models\Stand\Stand;
+use App\Models\Stand\StandAllocationStatus;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Cache;
 use Livewire\Livewire;
@@ -112,6 +113,35 @@ class DepartureStandFinderFormTest extends BaseFilamentTestCase
             'identifier' => '123',
             'aerodrome_reference_code' => 'C',
             'assignment_priority' => 1,
+        ]);
+
+        Livewire::test(DepartureStandFinderForm::class)
+            ->set('callsign', 'BAW999')
+            ->set('departureAirfield', $this->icaoCode)
+            ->set('aircraftType', $this->aircraft->id)
+            ->call('submit')
+            ->assertHasNoErrors()
+            ->assertDispatched('departureStandFinderFormSubmitted', [
+                'stand' => [
+                    'identifier' => '123',
+                    'airfield' => $this->icaoCode,
+                    'terminal' => null,
+                    'type' => null,
+                    'aerodrome_reference_code' => 'C',
+                    'max_aircraft_wingspan' => null,
+                    'max_aircraft_length' => null,
+                ],
+            ]);
+    }
+
+    public function testItFindsClosedForArrivalsStands()
+    {
+        $stand = Stand::factory()->create([
+            'airfield_id' => $this->airfield->id,
+            'identifier' => '123',
+            'aerodrome_reference_code' => 'C',
+            'assignment_priority' => 1,
+            'allocation_status' => StandAllocationStatus::ClosedForArrivals,
         ]);
 
         Livewire::test(DepartureStandFinderForm::class)

--- a/tests/app/Http/Livewire/RequestAStandFormTest.php
+++ b/tests/app/Http/Livewire/RequestAStandFormTest.php
@@ -4,6 +4,8 @@ namespace App\Http\Livewire;
 
 use App\BaseFilamentTestCase;
 use App\Models\Aircraft\Aircraft;
+use App\Models\Stand\Stand;
+use App\Models\Stand\StandAllocationStatus;
 use App\Models\Stand\StandAssignment;
 use App\Models\Stand\StandRequest;
 use App\Models\Stand\StandRequestHistory;
@@ -59,6 +61,15 @@ class RequestAStandFormTest extends BaseFilamentTestCase
         Livewire::test(RequestAStandForm::class)
             ->assertOk()
             ->assertSeeHtml('There are no stands available for assignment at your destination airfield.');
+    }
+
+    public function testItDoesntOfferClosedForArrivalsStands()
+    {
+        Stand::findOrFail(1)->update(['allocation_status' => StandAllocationStatus::ClosedForArrivals]);
+
+        Livewire::test(RequestAStandForm::class)
+            ->assertOk()
+            ->assertSet('stands', [2 => 'EGLL / 251']);
     }
 
     public function testItRenders()

--- a/tests/app/Models/Stand/StandTest.php
+++ b/tests/app/Models/Stand/StandTest.php
@@ -464,7 +464,7 @@ class StandTest extends BaseFunctionalTestCase
         Stand::findOrFail(1)->update(['allocation_status' => StandAllocationStatus::Unavailable]);
         Stand::findOrFail(2)->update(['allocation_status' => StandAllocationStatus::ClosedForArrivals]);
 
-        $stands = Stand::open()->get()->pluck('id')->toArray();
+        $stands = Stand::allocationOpen()->get()->pluck('id')->toArray();
         $this->assertEquals([3], $stands);
     }
 

--- a/tests/app/Models/Stand/StandTest.php
+++ b/tests/app/Models/Stand/StandTest.php
@@ -53,7 +53,7 @@ class StandTest extends BaseFunctionalTestCase
 
         $closedStand = Stand::find(1)->replicate();
         $closedStand->identifier = 'CLOSED';
-        $closedStand->closed_at = Carbon::now();
+        $closedStand->allocation_status = StandAllocationStatus::Unavailable;
         $closedStand->save();
 
         $stands = Stand::available()->get()->pluck('id')->toArray();
@@ -441,5 +441,71 @@ class StandTest extends BaseFunctionalTestCase
 
         $stands = Stand::orderByAerodromeReferenceCode('desc')->get()->pluck('id')->toArray();
         $this->assertEquals([1, 3, 2], $stands);
+    }
+
+    public function testAvailableIncludesClosedForArrivalsStands()
+    {
+        Stand::findOrFail(1)->update(['allocation_status' => StandAllocationStatus::ClosedForArrivals]);
+
+        $stands = Stand::available()->get()->pluck('id')->toArray();
+        $this->assertContains(1, $stands);
+    }
+
+    public function testAvailableForArrivalExcludesClosedForArrivalsStands()
+    {
+        Stand::findOrFail(1)->update(['allocation_status' => StandAllocationStatus::ClosedForArrivals]);
+
+        $stands = Stand::availableForArrival()->get()->pluck('id')->toArray();
+        $this->assertNotContains(1, $stands);
+    }
+
+    public function testOpenOnlyReturnsOpenStands()
+    {
+        Stand::findOrFail(1)->update(['allocation_status' => StandAllocationStatus::Unavailable]);
+        Stand::findOrFail(2)->update(['allocation_status' => StandAllocationStatus::ClosedForArrivals]);
+
+        $stands = Stand::open()->get()->pluck('id')->toArray();
+        $this->assertEquals([3], $stands);
+    }
+
+    public function testNotUnavailableExcludesOnlyUnavailableStands()
+    {
+        Stand::findOrFail(1)->update(['allocation_status' => StandAllocationStatus::Unavailable]);
+        Stand::findOrFail(2)->update(['allocation_status' => StandAllocationStatus::ClosedForArrivals]);
+
+        $stands = Stand::notUnavailable()->orderBy('id')->get()->pluck('id')->toArray();
+        $this->assertEquals([2, 3], $stands);
+    }
+
+    public function testIsOpen()
+    {
+        $this->assertTrue(Stand::findOrFail(1)->isOpen());
+        $this->assertFalse(Stand::findOrFail(1)->isClosedForArrivals());
+        $this->assertFalse(Stand::findOrFail(1)->isUnavailable());
+    }
+
+    public function testIsClosedForArrivals()
+    {
+        Stand::findOrFail(1)->update(['allocation_status' => StandAllocationStatus::ClosedForArrivals]);
+
+        $this->assertFalse(Stand::findOrFail(1)->isOpen());
+        $this->assertTrue(Stand::findOrFail(1)->isClosedForArrivals());
+        $this->assertFalse(Stand::findOrFail(1)->isUnavailable());
+    }
+
+    public function testIsUnavailable()
+    {
+        Stand::findOrFail(1)->update(['allocation_status' => StandAllocationStatus::Unavailable]);
+
+        $this->assertFalse(Stand::findOrFail(1)->isOpen());
+        $this->assertFalse(Stand::findOrFail(1)->isClosedForArrivals());
+        $this->assertTrue(Stand::findOrFail(1)->isUnavailable());
+    }
+
+    public function testCloseForArrivals()
+    {
+        Stand::findOrFail(1)->closeForArrivals();
+
+        $this->assertTrue(Stand::findOrFail(1)->isClosedForArrivals());
     }
 }

--- a/tests/app/Services/Stand/DepartureAllocationServiceTest.php
+++ b/tests/app/Services/Stand/DepartureAllocationServiceTest.php
@@ -6,6 +6,7 @@ use App\BaseFunctionalTestCase;
 use App\Events\StandAssignedEvent;
 use App\Events\StandUnassignedEvent;
 use App\Models\Stand\Stand;
+use App\Models\Stand\StandAllocationStatus;
 use App\Models\Stand\StandAssignment;
 use App\Services\NetworkAircraftService;
 use Illuminate\Support\Facades\DB;
@@ -292,6 +293,48 @@ class DepartureAllocationServiceTest extends BaseFunctionalTestCase
         $this->service->assignStandsForDeparture();
         $this->assertTrue(StandAssignment::where('callsign', 'RYR787')->exists());
         Event::assertNotDispatched(StandUnassignedEvent::class);
+    }
+
+    public function testItDoesntAssignUnavailableOccupiedStandsAtDepartureAirfields()
+    {
+        Stand::findOrFail(2)->update(['allocation_status' => StandAllocationStatus::Unavailable]);
+
+        $aircraft = NetworkAircraftService::createOrUpdateNetworkAircraft(
+            'RYR787',
+            [
+                'latitude' => 51.47187222,
+                'longitude' => -0.48601389,
+                'groundspeed' => 0,
+                'altitude' => 0,
+                'planned_depairport' => 'EGLL',
+            ]
+        );
+        $aircraft->occupiedStand()->sync([2]);
+        $this->service->assignStandsForDeparture();
+
+        $this->assertFalse(StandAssignment::where('callsign', 'RYR787')->exists());
+        Event::assertNotDispatched(StandAssignedEvent::class);
+    }
+
+    public function testItAssignsClosedForArrivalsOccupiedStandsAtDepartureAirfields()
+    {
+        Stand::findOrFail(2)->update(['allocation_status' => StandAllocationStatus::ClosedForArrivals]);
+
+        $aircraft = NetworkAircraftService::createOrUpdateNetworkAircraft(
+            'RYR787',
+            [
+                'latitude' => 51.47187222,
+                'longitude' => -0.48601389,
+                'groundspeed' => 0,
+                'altitude' => 0,
+                'planned_depairport' => 'EGLL',
+            ]
+        );
+        $aircraft->occupiedStand()->sync([2]);
+        $this->service->assignStandsForDeparture();
+
+        $this->assertTrue(StandAssignment::where('callsign', 'RYR787')->where('stand_id', 2)->exists());
+        Event::assertDispatched(StandAssignedEvent::class);
     }
 
     private function addStandAssignment(string $callsign, int $standId): void

--- a/tests/app/Services/Stand/StandAssignmentsServiceTest.php
+++ b/tests/app/Services/Stand/StandAssignmentsServiceTest.php
@@ -7,6 +7,7 @@ use App\Events\StandAssignedEvent;
 use App\Events\StandUnassignedEvent;
 use App\Exceptions\Stand\StandNotFoundException;
 use App\Models\Stand\Stand;
+use App\Models\Stand\StandAllocationStatus;
 use App\Models\Stand\StandAssignment;
 use App\Models\Vatsim\NetworkAircraft;
 use Illuminate\Support\Facades\Event;
@@ -105,6 +106,32 @@ class StandAssignmentsServiceTest extends BaseFunctionalTestCase
         $this->mockHistoryService->shouldReceive('createHistoryItem')
             ->never();
         $this->service->createStandAssignment('BAW123', 999, 'test');
+    }
+
+    public function testCreatingAStandAssignmentThrowsExceptionIfStandUnavailable()
+    {
+        Stand::findOrFail(1)->update(['allocation_status' => StandAllocationStatus::Unavailable]);
+
+        $this->expectException(StandNotFoundException::class);
+        $this->mockHistoryService->shouldReceive('createHistoryItem')
+            ->never();
+        $this->service->createStandAssignment('BAW123', 1, 'test');
+    }
+
+    public function testItCreatesAnAssignmentForClosedForArrivalsStands()
+    {
+        Stand::findOrFail(1)->update(['allocation_status' => StandAllocationStatus::ClosedForArrivals]);
+
+        $this->mockHistoryService->shouldReceive('createHistoryItem')
+            ->once();
+        $this->service->createStandAssignment('BAW123', 1, 'User');
+        $this->assertDatabaseHas(
+            'stand_assignments',
+            [
+                'callsign' => 'BAW123',
+                'stand_id' => 1,
+            ]
+        );
     }
 
     public function testItCreatesAnAssignment()

--- a/tests/app/Services/Stand/StandStatusServiceTest.php
+++ b/tests/app/Services/Stand/StandStatusServiceTest.php
@@ -5,6 +5,7 @@ namespace App\Services\Stand;
 use App\BaseFunctionalTestCase;
 use App\Models\Aircraft\Aircraft;
 use App\Models\Stand\Stand;
+use App\Models\Stand\StandAllocationStatus;
 use App\Models\Stand\StandAssignment;
 use App\Models\Stand\StandReservation;
 use App\Models\Vatsim\NetworkAircraft;
@@ -148,7 +149,7 @@ class StandStatusServiceTest extends BaseFunctionalTestCase
                 'longitude' => -'6.22207000',
             ]
         );
-        $stand10->close();
+        $stand10->update(['allocation_status' => StandAllocationStatus::Unavailable]);
 
         // Stand 11 is requested
         $stand11 = Stand::create(
@@ -345,6 +346,24 @@ class StandStatusServiceTest extends BaseFunctionalTestCase
             ],
             StandStatusService::getAirfieldStandStatus('EGLL')
         );
+    }
+
+    public function testItReturnsClosedForArrivalsStandsAsAvailable()
+    {
+        $stand = Stand::create(
+            [
+                'airfield_id' => 1,
+                'identifier' => 'TESTCLOSED',
+                'latitude' => '54.65882800',
+                'longitude' => -'6.22207000',
+            ]
+        );
+        $stand->update(['allocation_status' => StandAllocationStatus::ClosedForArrivals]);
+
+        $statuses = collect(StandStatusService::getAirfieldStandStatus('EGLL'))
+            ->firstWhere('identifier', 'TESTCLOSED');
+
+        $this->assertEquals('available', $statuses['status']);
     }
 
 


### PR DESCRIPTION
fixes #1876

Replaced closed/open stand with a 3-way toggle:
 - Used for allocation (open fully)
 - Closed for arrivals (picked up by UKCP for deps but not assigned for arrs)
 - Unavailable (closed completely)

<img width="280" height="184" alt="image" src="https://github.com/user-attachments/assets/211fb6c8-d25f-4390-8673-f3237c2fa9fc" />
