### PR TITLE
chore: HoldFactory outbound_leg_value exceeding form validation bound Hold factory leg value range

### DIFF
--- a/database/factories/Hold/HoldFactory.php
+++ b/database/factories/Hold/HoldFactory.php
@@ -28,7 +28,7 @@ class HoldFactory extends Factory
             'minimum_altitude' => $this->faker->numberBetween(7000, 24000),
             'maximum_altitude' => $this->faker->numberBetween(7000, 24000),
             'turn_direction' => $this->faker->randomElement(['left', 'right']),
-            'outbound_leg_value' => $this->faker->randomFloat(1, 0.5, 100.5),
+            'outbound_leg_value' => $this->faker->randomFloat(1, 0.5, 100),
             'outbound_leg_unit' => 2,
             'description' => $this->faker->word
         ];


### PR DESCRIPTION
## Summary
- `HoldFactory` generated `outbound_leg_value` as a random float in `[0.5, 100.5]`, but the hold form in `HoldsRelationManager` validates it with `minValue(0.5)`/`maxValue(100)`.
- Tests that prefill the edit form from `Hold::factory()->make()` (e.g. `NavaidResourceTest`) would intermittently fail Livewire validation whenever the factory rolled a value between 100.1 and 100.5 (~0.5% of runs).
- Capped the factory's upper bound at `100` to match the form's validation, so it's no longer possible to generate an out-of-range value.

Fixes #1947

## Test plan
- [x] Reviewed all call sites of `outbound_leg_value` to confirm `100` aligns with the form's `maxValue(100)`.
- [x] Ran `NavaidResourceTest` (114 tests) 5 times in a row — all passed clean with no failures.